### PR TITLE
Integrate MCP server as CLI subcommand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,35 +19,42 @@ jobs:
       - name: Build for arm64
         run: swift build -c release --arch arm64
 
-      - name: Create Universal Binaries
+      - name: Create Universal Binary
         run: |
           mkdir -p .build/universal
-
           lipo -create \
             .build/arm64-apple-macosx/release/xcstrings-crud \
             .build/x86_64-apple-macosx/release/xcstrings-crud \
             -output .build/universal/xcstrings-crud
-
-          lipo -create \
-            .build/arm64-apple-macosx/release/xcstrings-crud-mcp \
-            .build/x86_64-apple-macosx/release/xcstrings-crud-mcp \
-            -output .build/universal/xcstrings-crud-mcp
 
       - name: Create Archive
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
           cd .build/universal
-          tar -czvf "xcstrings-crud-${TAG_NAME}-darwin-universal.tar.gz" xcstrings-crud xcstrings-crud-mcp
+          tar -czvf "xcstrings-crud-${TAG_NAME}-darwin-universal.tar.gz" xcstrings-crud
+
+      - name: Create Artifact Bundle
+        uses: giginet/github-action-artifactbundle@v2
+        id: artifactbundle
+        with:
+          artifact_name: xcstrings-crud
 
       - name: Generate Checksums
+        env:
+          BUNDLE_PATH: ${{ steps.artifactbundle.outputs.bundle_path }}
         run: |
           cd .build/universal
-          shasum -a 256 *.tar.gz > checksums.txt
+          cp "${BUNDLE_PATH}" .
+          shasum -a 256 *.tar.gz *.artifactbundle.zip > checksums.txt
 
       - name: Upload Release Assets
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            .build/universal/xcstrings-crud-*-darwin-universal.tar.gz
-            .build/universal/checksums.txt
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+          BUNDLE_FILENAME: ${{ steps.artifactbundle.outputs.bundle_filename }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${TAG_NAME}" \
+            ".build/universal/xcstrings-crud-${TAG_NAME}-darwin-universal.tar.gz" \
+            ".build/universal/${BUNDLE_FILENAME}" \
+            ".build/universal/checksums.txt"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,9 @@ swift build -c release # Release build
 ## Architecture
 
 - `XCStringsKit/` - Core library (models, parser, reader, writer, stats)
-- `XCStringsCLI/` - CLI commands using ArgumentParser
+- `XCStringsCLI/` - CLI commands using ArgumentParser (includes MCP subcommand)
 - `XCStringsMCP/` - MCP server using swift-sdk
-- `xcstrings-crud/` - CLI entry point
-- `xcstrings-crud-mcp/` - MCP entry point
+- `xcstrings-crud/` - CLI entry point (`xcstrings-crud mcp` for MCP server)
 
 ## Code Style
 

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,6 @@ let package = Package(
     platforms: [.macOS(.v13)],
     products: [
         .executable(name: "xcstrings-crud", targets: ["xcstrings-crud"]),
-        .executable(name: "xcstrings-crud-mcp", targets: ["xcstrings-crud-mcp"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
@@ -23,6 +22,7 @@ let package = Package(
             name: "XCStringsCLI",
             dependencies: [
                 "XCStringsKit",
+                "XCStringsMCP",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ]
         ),
@@ -40,12 +40,6 @@ let package = Package(
         .executableTarget(
             name: "xcstrings-crud",
             dependencies: ["XCStringsCLI"]
-        ),
-
-        // MCP実行ファイル
-        .executableTarget(
-            name: "xcstrings-crud-mcp",
-            dependencies: ["XCStringsMCP"]
         ),
 
         // テスト

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ By using the MCP server or CLI, AI assistants can work with xcstrings files of a
 mise use -g ubi:Ryu0118/xcstrings-crud
 ```
 
-This installs two binaries: `xcstrings-crud` (CLI) and `xcstrings-crud-mcp` (MCP server).
-
 ### Build from source
 
 ```bash
@@ -32,7 +30,7 @@ cd xcstrings-crud
 swift build -c release
 ```
 
-Binaries will be at `.build/release/xcstrings-crud` and `.build/release/xcstrings-crud-mcp`.
+Binary will be at `.build/release/xcstrings-crud`.
 
 ## CLI Usage
 
@@ -104,6 +102,12 @@ xcstrings-crud delete key "Hello" --file path/to/Localizable.xcstrings --lang ja
 
 ## MCP Server
 
+The MCP server is available as a subcommand:
+
+```bash
+xcstrings-crud mcp
+```
+
 ### Configuration
 
 Add to your Claude Code MCP settings:
@@ -111,8 +115,9 @@ Add to your Claude Code MCP settings:
 ```json
 {
   "mcpServers": {
-    "xcstrings-crud-mcp": {
-      "command": "xcstrings-crud-mcp"
+    "xcstrings-crud": {
+      "command": "xcstrings-crud",
+      "args": ["mcp"]
     }
   }
 }

--- a/Sources/XCStringsCLI/MCPCommand.swift
+++ b/Sources/XCStringsCLI/MCPCommand.swift
@@ -1,0 +1,15 @@
+import ArgumentParser
+import XCStringsMCP
+
+@available(macOS 13.0, *)
+struct MCPCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mcp",
+        abstract: "Start the MCP server"
+    )
+
+    func run() async throws {
+        let server = XCStringsMCPServer()
+        try await server.run()
+    }
+}

--- a/Sources/XCStringsCLI/XCStringsCLI.swift
+++ b/Sources/XCStringsCLI/XCStringsCLI.swift
@@ -16,6 +16,7 @@ public struct XCStringsCLI: AsyncParsableCommand {
             DeleteCommand.self,
             RenameCommand.self,
             StatsCommand.self,
+            MCPCommand.self,
         ]
     )
 

--- a/Sources/xcstrings-crud-mcp/main.swift
+++ b/Sources/xcstrings-crud-mcp/main.swift
@@ -1,4 +1,0 @@
-import XCStringsMCP
-
-let server = XCStringsMCPServer()
-try await server.run()


### PR DESCRIPTION
## Summary
- Merge `xcstrings-crud` and `xcstrings-crud-mcp` into a single binary
- MCP server is now started via `xcstrings-crud mcp` subcommand
- Add artifact bundle generation to release workflow for better mise/Swift PM integration

## Changes

**Before:**
```
xcstrings-crud          # CLI
xcstrings-crud-mcp      # MCP Server
```

**After:**
```
xcstrings-crud          # CLI (includes mcp subcommand)
xcstrings-crud mcp      # Start MCP Server
```

## MCP Configuration

```json
{
  "mcpServers": {
    "xcstrings-crud": {
      "command": "xcstrings-crud",
      "args": ["mcp"]
    }
  }
}
```

## Test plan
- [x] `swift build` succeeds
- [x] `xcstrings-crud --help` shows `mcp` subcommand
- [x] `xcstrings-crud mcp --help` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)