### PR TITLE
Fix MCP server exiting immediately after start

### DIFF
--- a/Sources/XCStringsMCP/MCPServer.swift
+++ b/Sources/XCStringsMCP/MCPServer.swift
@@ -26,6 +26,7 @@ public struct XCStringsMCPServer {
 
         let transport = StdioTransport()
         try await server.start(transport: transport)
+        await server.waitUntilCompleted()
     }
 
     // MARK: - Tool Definitions


### PR DESCRIPTION
## Summary
- Add `server.waitUntilCompleted()` call to keep the MCP server running until the client disconnects
- Without this fix, the server would start and immediately exit because `start()` returns after spawning the message handling task

## Test plan
- [x] Verified MCP server stays running after start
- [x] Verified initialize request returns proper response
- [x] Test with Claude Code MCP integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)