### PR TITLE
Add batch language operations support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,11 @@ xcstrings-crud add key "Hello" --file path/to/Localizable.xcstrings --lang ja --
 # Add translation (multiple languages)
 xcstrings-crud add key "Hello" --file path/to/Localizable.xcstrings --translations '{"ja":"こんにちは","en":"Hello"}'
 
-# Update translation
+# Update translation (single language)
 xcstrings-crud update key "Hello" --file path/to/Localizable.xcstrings --lang ja --value "こんにちは！"
+
+# Update translations (multiple languages)
+xcstrings-crud update key "Hello" --file path/to/Localizable.xcstrings -t ja:こんにちは en:Hello de:Hallo
 
 # Rename key
 xcstrings-crud rename key "Hello" --file path/to/Localizable.xcstrings --to "Greeting"
@@ -94,7 +97,10 @@ xcstrings-crud rename key "Hello" --file path/to/Localizable.xcstrings --to "Gre
 xcstrings-crud delete key "Hello" --file path/to/Localizable.xcstrings
 
 # Delete translation for specific language only
-xcstrings-crud delete key "Hello" --file path/to/Localizable.xcstrings --lang ja
+xcstrings-crud delete key "Hello" --file path/to/Localizable.xcstrings -l ja
+
+# Delete translations for multiple languages
+xcstrings-crud delete key "Hello" --file path/to/Localizable.xcstrings -l ja en fr
 ```
 
 ### Common Options
@@ -138,11 +144,14 @@ Add to your Claude Code MCP settings:
 | `xcstrings_check_coverage` | Check key language coverage |
 | `xcstrings_stats_coverage` | Get overall coverage statistics |
 | `xcstrings_stats_progress` | Get translation progress by language |
-| `xcstrings_add_translation` | Add translation |
-| `xcstrings_update_translation` | Update translation |
+| `xcstrings_add_translation` | Add translation for single language |
+| `xcstrings_add_translations` | Add translations for multiple languages |
+| `xcstrings_update_translation` | Update translation for single language |
+| `xcstrings_update_translations` | Update translations for multiple languages |
 | `xcstrings_rename_key` | Rename key |
 | `xcstrings_delete_key` | Delete entire key |
-| `xcstrings_delete_translation` | Delete translation for specific language |
+| `xcstrings_delete_translation` | Delete translation for single language |
+| `xcstrings_delete_translations` | Delete translations for multiple languages |
 
 ## Requirements
 

--- a/Sources/XCStringsCLI/UpdateCommand.swift
+++ b/Sources/XCStringsCLI/UpdateCommand.swift
@@ -56,7 +56,7 @@ extension UpdateCommand {
             let parser = XCStringsParser(path: file)
 
             if !translations.isEmpty {
-                let translationsDict = try parseTranslations(translations)
+                let translationsDict = try TranslationParser.parse(translations)
                 try await parser.updateTranslations(key: key, translations: translationsDict)
                 let result = CLIResult.success(message: "Translations updated successfully for \(translationsDict.count) languages")
                 try output(result, pretty: pretty)
@@ -65,19 +65,6 @@ extension UpdateCommand {
                 let result = CLIResult.success(message: "Translation updated successfully")
                 try output(result, pretty: pretty)
             }
-        }
-
-        private func parseTranslations(_ translations: [String]) throws -> [String: String] {
-            var result: [String: String] = [:]
-            for translation in translations {
-                guard let colonIndex = translation.firstIndex(of: ":") else {
-                    throw ValidationError("Invalid translation format: '\(translation)'. Expected 'lang:value'")
-                }
-                let lang = String(translation[..<colonIndex])
-                let value = String(translation[translation.index(after: colonIndex)...])
-                result[lang] = value
-            }
-            return result
         }
     }
 }

--- a/Sources/XCStringsCLI/UpdateCommand.swift
+++ b/Sources/XCStringsCLI/UpdateCommand.swift
@@ -23,21 +23,61 @@ extension UpdateCommand {
         @Option(name: .shortAndLong, help: "Path to the xcstrings file")
         var file: String
 
-        @Option(name: .shortAndLong, help: "Language code for the translation")
-        var lang: String
+        @Option(name: .shortAndLong, help: "Language code for the translation (use with -v)")
+        var lang: String?
 
-        @Option(name: .shortAndLong, help: "New translation value")
-        var value: String
+        @Option(name: .shortAndLong, help: "New translation value (use with -l)")
+        var value: String?
+
+        @Option(name: .shortAndLong, parsing: .upToNextOption, help: "Translations in lang:value format (e.g., -t ja:こんにちは en:Hello)")
+        var translations: [String] = []
 
         @Flag(name: .long, help: "Output in pretty-printed JSON format")
         var pretty = false
 
+        func validate() throws {
+            let hasSingleLang = lang != nil && value != nil
+            let hasMultiple = !translations.isEmpty
+
+            if hasSingleLang && hasMultiple {
+                throw ValidationError("Cannot use both -l/-v and -t options together")
+            }
+
+            if !hasSingleLang && !hasMultiple {
+                throw ValidationError("Either -l and -v, or -t must be specified")
+            }
+
+            if (lang != nil) != (value != nil) {
+                throw ValidationError("Both -l and -v must be specified together")
+            }
+        }
+
         func run() async throws {
             let parser = XCStringsParser(path: file)
-            try await parser.updateTranslation(key: key, language: lang, value: value)
 
-            let result = CLIResult.success(message: "Translation updated successfully")
-            try output(result, pretty: pretty)
+            if !translations.isEmpty {
+                let translationsDict = try parseTranslations(translations)
+                try await parser.updateTranslations(key: key, translations: translationsDict)
+                let result = CLIResult.success(message: "Translations updated successfully for \(translationsDict.count) languages")
+                try output(result, pretty: pretty)
+            } else if let lang = lang, let value = value {
+                try await parser.updateTranslation(key: key, language: lang, value: value)
+                let result = CLIResult.success(message: "Translation updated successfully")
+                try output(result, pretty: pretty)
+            }
+        }
+
+        private func parseTranslations(_ translations: [String]) throws -> [String: String] {
+            var result: [String: String] = [:]
+            for translation in translations {
+                guard let colonIndex = translation.firstIndex(of: ":") else {
+                    throw ValidationError("Invalid translation format: '\(translation)'. Expected 'lang:value'")
+                }
+                let lang = String(translation[..<colonIndex])
+                let value = String(translation[translation.index(after: colonIndex)...])
+                result[lang] = value
+            }
+            return result
         }
     }
 }

--- a/Sources/XCStringsKit/TranslationParser.swift
+++ b/Sources/XCStringsKit/TranslationParser.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Parses translation input formats
+public enum TranslationParser {
+    /// Parse "lang:value" format strings into a dictionary
+    /// - Parameter inputs: Array of strings in "lang:value" format (e.g., ["ja:こんにちは", "en:Hello"])
+    /// - Returns: Dictionary mapping language codes to values
+    /// - Throws: `TranslationParseError` if format is invalid
+    public static func parse(_ inputs: [String]) throws -> [String: String] {
+        try inputs.reduce(into: [:]) { result, input in
+            let (lang, value) = try parseSingle(input)
+            result[lang] = value
+        }
+    }
+
+    /// Parse a single "lang:value" format string
+    /// - Parameter input: String in "lang:value" format
+    /// - Returns: Tuple of (language, value)
+    /// - Throws: `TranslationParseError` if format is invalid
+    public static func parseSingle(_ input: String) throws -> (language: String, value: String) {
+        guard let colonIndex = input.firstIndex(of: ":") else {
+            throw TranslationParseError.invalidFormat(input)
+        }
+        let lang = String(input[..<colonIndex])
+        let value = String(input[input.index(after: colonIndex)...])
+
+        guard !lang.isEmpty else {
+            throw TranslationParseError.emptyLanguage(input)
+        }
+
+        return (lang, value)
+    }
+}
+
+/// Errors that can occur when parsing translation input
+public enum TranslationParseError: Error, LocalizedError, Equatable {
+    case invalidFormat(String)
+    case emptyLanguage(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidFormat(let input):
+            return "Invalid translation format: '\(input)'. Expected 'lang:value'"
+        case .emptyLanguage(let input):
+            return "Empty language code in: '\(input)'"
+        }
+    }
+}

--- a/Sources/XCStringsKit/XCStringsParser.swift
+++ b/Sources/XCStringsKit/XCStringsParser.swift
@@ -108,6 +108,13 @@ package actor XCStringsParser {
         try save(updated)
     }
 
+    /// Update translations for multiple languages
+    package func updateTranslations(key: String, translations: [String: String]) throws {
+        let file = try load()
+        let updated = try XCStringsWriter.updateTranslations(in: file, key: key, translations: translations)
+        try save(updated)
+    }
+
     /// Rename a key
     package func renameKey(from oldKey: String, to newKey: String) throws {
         let file = try load()
@@ -128,6 +135,13 @@ package actor XCStringsParser {
     package func deleteTranslation(key: String, language: String) throws {
         let file = try load()
         let updated = try XCStringsWriter.deleteTranslation(from: file, key: key, language: language)
+        try save(updated)
+    }
+
+    /// Delete translations for multiple languages
+    package func deleteTranslations(key: String, languages: [String]) throws {
+        let file = try load()
+        let updated = try XCStringsWriter.deleteTranslations(from: file, key: key, languages: languages)
         try save(updated)
     }
 }

--- a/Sources/XCStringsKit/XCStringsWriter.swift
+++ b/Sources/XCStringsKit/XCStringsWriter.swift
@@ -85,6 +85,31 @@ enum XCStringsWriter {
         return result
     }
 
+    /// Update translations for multiple languages
+    static func updateTranslations(
+        in file: XCStringsFile,
+        key: String,
+        translations: [String: String]
+    ) throws -> XCStringsFile {
+        var result = file
+
+        guard result.strings[key] != nil else {
+            throw XCStringsError.keyNotFound(key: key)
+        }
+
+        for (language, value) in translations {
+            guard result.strings[key]?.localizations?[language] != nil else {
+                throw XCStringsError.languageNotFound(language: language, key: key)
+            }
+
+            result.strings[key]?.localizations?[language] = Localization(
+                stringUnit: StringUnit(state: "translated", value: value)
+            )
+        }
+
+        return result
+    }
+
     /// Rename a key
     static func renameKey(
         in file: XCStringsFile,
@@ -140,6 +165,29 @@ enum XCStringsWriter {
         }
 
         result.strings[key]?.localizations?.removeValue(forKey: language)
+
+        return result
+    }
+
+    /// Delete translations for multiple languages
+    static func deleteTranslations(
+        from file: XCStringsFile,
+        key: String,
+        languages: [String]
+    ) throws -> XCStringsFile {
+        var result = file
+
+        guard result.strings[key] != nil else {
+            throw XCStringsError.keyNotFound(key: key)
+        }
+
+        for language in languages {
+            guard result.strings[key]?.localizations?[language] != nil else {
+                throw XCStringsError.languageNotFound(language: language, key: key)
+            }
+
+            result.strings[key]?.localizations?.removeValue(forKey: language)
+        }
 
         return result
     }

--- a/Tests/XCStringsKitTests/TranslationParserTests.swift
+++ b/Tests/XCStringsKitTests/TranslationParserTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import XCStringsKit
+
+@Suite("TranslationParser")
+struct TranslationParserTests {
+    // MARK: - parse
+
+    @Test("parse converts array of lang:value strings to dictionary")
+    func parseMultiple() throws {
+        let inputs = ["ja:こんにちは", "en:Hello", "de:Hallo"]
+
+        let result = try TranslationParser.parse(inputs)
+
+        #expect(result == ["ja": "こんにちは", "en": "Hello", "de": "Hallo"])
+    }
+
+    @Test("parse returns empty dictionary for empty input")
+    func parseEmpty() throws {
+        let result = try TranslationParser.parse([])
+
+        #expect(result.isEmpty)
+    }
+
+    @Test("parse handles value containing colons")
+    func parseValueWithColons() throws {
+        let inputs = ["en:Time: 10:30"]
+
+        let result = try TranslationParser.parse(inputs)
+
+        #expect(result == ["en": "Time: 10:30"])
+    }
+
+    @Test("parse handles empty value")
+    func parseEmptyValue() throws {
+        let inputs = ["en:"]
+
+        let result = try TranslationParser.parse(inputs)
+
+        #expect(result == ["en": ""])
+    }
+
+    @Test("parse throws for missing colon")
+    func parseMissingColon() {
+        let inputs = ["ja-invalid"]
+
+        #expect(throws: TranslationParseError.self) {
+            _ = try TranslationParser.parse(inputs)
+        }
+    }
+
+    @Test("parse throws for empty language")
+    func parseEmptyLanguage() {
+        let inputs = [":value"]
+
+        #expect(throws: TranslationParseError.self) {
+            _ = try TranslationParser.parse(inputs)
+        }
+    }
+
+    // MARK: - parseSingle
+
+    @Test("parseSingle extracts language and value")
+    func parseSingle() throws {
+        let (language, value) = try TranslationParser.parseSingle("ja:こんにちは")
+
+        #expect(language == "ja")
+        #expect(value == "こんにちは")
+    }
+
+    @Test("parseSingle handles hyphenated language codes")
+    func parseSingleHyphenatedLang() throws {
+        let (language, value) = try TranslationParser.parseSingle("zh-Hans:你好")
+
+        #expect(language == "zh-Hans")
+        #expect(value == "你好")
+    }
+
+    // MARK: - TranslationParseError
+
+    @Test("TranslationParseError.invalidFormat has descriptive message")
+    func errorInvalidFormat() {
+        let error = TranslationParseError.invalidFormat("bad-input")
+
+        #expect(error.errorDescription?.contains("bad-input") == true)
+        #expect(error.errorDescription?.contains("lang:value") == true)
+    }
+
+    @Test("TranslationParseError.emptyLanguage has descriptive message")
+    func errorEmptyLanguage() {
+        let error = TranslationParseError.emptyLanguage(":value")
+
+        #expect(error.errorDescription?.contains(":value") == true)
+        #expect(error.errorDescription?.contains("Empty language") == true)
+    }
+}

--- a/Tests/XCStringsKitTests/XCStringsWriterTests.swift
+++ b/Tests/XCStringsKitTests/XCStringsWriterTests.swift
@@ -90,6 +90,41 @@ struct XCStringsWriterTests {
         }
     }
 
+    // MARK: - updateTranslations
+
+    @Test("updateTranslations updates multiple languages")
+    func updateTranslationsMultiple() throws {
+        var file = try loadFixture(TestFixtures.singleKeyMultipleLangs)
+
+        file = try XCStringsWriter.updateTranslations(in: file, key: "Hello", translations: [
+            "en": "Hi",
+            "ja": "やあ",
+            "de": "Hi",
+        ])
+
+        #expect(file.strings["Hello"]?.localizations?["en"]?.stringUnit?.value == "Hi")
+        #expect(file.strings["Hello"]?.localizations?["ja"]?.stringUnit?.value == "やあ")
+        #expect(file.strings["Hello"]?.localizations?["de"]?.stringUnit?.value == "Hi")
+    }
+
+    @Test("updateTranslations throws for non-existent key")
+    func updateTranslationsKeyNotFound() throws {
+        let file = try loadFixture(TestFixtures.singleKeyMultipleLangs)
+
+        #expect(throws: XCStringsError.self) {
+            _ = try XCStringsWriter.updateTranslations(in: file, key: "NonExistent", translations: ["en": "Value"])
+        }
+    }
+
+    @Test("updateTranslations throws for non-existent language")
+    func updateTranslationsLanguageNotFound() throws {
+        let file = try loadFixture(TestFixtures.singleKeyMultipleLangs)
+
+        #expect(throws: XCStringsError.self) {
+            _ = try XCStringsWriter.updateTranslations(in: file, key: "Hello", translations: ["fr": "Bonjour"])
+        }
+    }
+
     // MARK: - renameKey
 
     @Test("renameKey renames key")
@@ -168,6 +203,37 @@ struct XCStringsWriterTests {
 
         #expect(throws: XCStringsError.self) {
             _ = try XCStringsWriter.deleteTranslation(from: file, key: "Hello", language: "fr")
+        }
+    }
+
+    // MARK: - deleteTranslations
+
+    @Test("deleteTranslations removes multiple languages")
+    func deleteTranslationsMultiple() throws {
+        var file = try loadFixture(TestFixtures.singleKeyMultipleLangs)
+
+        file = try XCStringsWriter.deleteTranslations(from: file, key: "Hello", languages: ["ja", "de"])
+
+        #expect(file.strings["Hello"]?.localizations?["ja"] == nil)
+        #expect(file.strings["Hello"]?.localizations?["de"] == nil)
+        #expect(file.strings["Hello"]?.localizations?["en"] != nil)
+    }
+
+    @Test("deleteTranslations throws for non-existent key")
+    func deleteTranslationsKeyNotFound() throws {
+        let file = try loadFixture(TestFixtures.singleKeyMultipleLangs)
+
+        #expect(throws: XCStringsError.self) {
+            _ = try XCStringsWriter.deleteTranslations(from: file, key: "NonExistent", languages: ["en"])
+        }
+    }
+
+    @Test("deleteTranslations throws for non-existent language")
+    func deleteTranslationsLanguageNotFound() throws {
+        let file = try loadFixture(TestFixtures.singleKeyMultipleLangs)
+
+        #expect(throws: XCStringsError.self) {
+            _ = try XCStringsWriter.deleteTranslations(from: file, key: "Hello", languages: ["fr"])
         }
     }
 


### PR DESCRIPTION
## Summary
- 複数言語の一括操作（追加・更新・削除）をサポート
- MCP ツールに `xcstrings_add_translations`, `xcstrings_update_translations`, `xcstrings_delete_translations` を追加
- CLI の `update` コマンドに `-t` オプション、`delete` コマンドに複数 `-l` オプションを追加

## Test plan
- [x] `swift build` でビルド成功を確認
- [x] `swift test` で全87テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)