### PR TITLE
Refactor: Extract shared CLI output logic and JSON parsing

### DIFF
--- a/Sources/XCStringsCLI/AddCommand.swift
+++ b/Sources/XCStringsCLI/AddCommand.swift
@@ -39,35 +39,16 @@ extension AddCommand {
             let parser = XCStringsParser(path: file)
 
             if let translationsJSON = translations {
-                // 複数言語一括追加
-                guard let data = translationsJSON.data(using: .utf8),
-                      let translationDict = try? JSONDecoder().decode([String: String].self, from: data)
-                else {
-                    throw XCStringsError.invalidJSON(reason: "Invalid translations JSON format")
-                }
+                let translationDict = try TranslationParser.parseJSON(translationsJSON)
                 try await parser.addTranslations(key: key, translations: translationDict)
             } else if let lang = lang, let value = value {
-                // 単一言語追加
                 try await parser.addTranslation(key: key, language: lang, value: value)
             } else {
                 throw ValidationError("Either --lang and --value, or --translations must be provided")
             }
 
             let result = CLIResult.success(message: "Translation added successfully")
-            try output(result, pretty: pretty)
+            try CLIOutput.printJSON(result, pretty: pretty)
         }
-    }
-}
-
-// MARK: - Output Helper
-
-private func output<T: Encodable>(_ value: T, pretty: Bool) throws {
-    let encoder = JSONEncoder()
-    if pretty {
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    }
-    let data = try encoder.encode(value)
-    if let json = String(data: data, encoding: .utf8) {
-        print(json)
     }
 }

--- a/Sources/XCStringsCLI/CLIOutput.swift
+++ b/Sources/XCStringsCLI/CLIOutput.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// CLI output utilities
+public enum CLIOutput {
+    /// Encode and print a value as JSON
+    /// - Parameters:
+    ///   - value: The value to encode
+    ///   - pretty: Whether to use pretty-printed formatting
+    public static func printJSON<T: Encodable>(_ value: T, pretty: Bool) throws {
+        let encoder = JSONEncoder()
+        if pretty {
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        }
+        let data = try encoder.encode(value)
+        if let json = String(data: data, encoding: .utf8) {
+            print(json)
+        }
+    }
+}

--- a/Sources/XCStringsCLI/CheckCommand.swift
+++ b/Sources/XCStringsCLI/CheckCommand.swift
@@ -51,20 +51,7 @@ extension CheckCommand {
         func run() async throws {
             let parser = XCStringsParser(path: file)
             let coverage = try await parser.checkCoverage(key)
-            try output(coverage, pretty: pretty)
+            try CLIOutput.printJSON(coverage, pretty: pretty)
         }
-    }
-}
-
-// MARK: - Output Helper
-
-private func output<T: Encodable>(_ value: T, pretty: Bool) throws {
-    let encoder = JSONEncoder()
-    if pretty {
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    }
-    let data = try encoder.encode(value)
-    if let json = String(data: data, encoding: .utf8) {
-        print(json)
     }
 }

--- a/Sources/XCStringsCLI/DeleteCommand.swift
+++ b/Sources/XCStringsCLI/DeleteCommand.swift
@@ -31,33 +31,21 @@ extension DeleteCommand {
 
         func run() async throws {
             let parser = XCStringsParser(path: file)
+            let result: CLIResult
 
-            if lang.isEmpty {
+            switch lang.count {
+            case 0:
                 try await parser.deleteKey(key)
-                let result = CLIResult.success(message: "Key deleted successfully")
-                try output(result, pretty: pretty)
-            } else if lang.count == 1 {
+                result = .success(message: "Key deleted successfully")
+            case 1:
                 try await parser.deleteTranslation(key: key, language: lang[0])
-                let result = CLIResult.success(message: "Translation for '\(lang[0])' deleted successfully")
-                try output(result, pretty: pretty)
-            } else {
+                result = .success(message: "Translation for '\(lang[0])' deleted successfully")
+            default:
                 try await parser.deleteTranslations(key: key, languages: lang)
-                let result = CLIResult.success(message: "Translations deleted successfully for \(lang.count) languages")
-                try output(result, pretty: pretty)
+                result = .success(message: "Translations deleted successfully for \(lang.count) languages")
             }
+
+            try CLIOutput.printJSON(result, pretty: pretty)
         }
-    }
-}
-
-// MARK: - Output Helper
-
-private func output<T: Encodable>(_ value: T, pretty: Bool) throws {
-    let encoder = JSONEncoder()
-    if pretty {
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    }
-    let data = try encoder.encode(value)
-    if let json = String(data: data, encoding: .utf8) {
-        print(json)
     }
 }

--- a/Sources/XCStringsCLI/GetCommand.swift
+++ b/Sources/XCStringsCLI/GetCommand.swift
@@ -32,7 +32,7 @@ extension GetCommand {
         func run() async throws {
             let parser = XCStringsParser(path: file)
             let translations = try await parser.getTranslation(key: key, language: lang)
-            try output(translations, pretty: pretty)
+            try CLIOutput.printJSON(translations, pretty: pretty)
         }
     }
 
@@ -50,18 +50,5 @@ extension GetCommand {
             let sourceLanguage = try await parser.getSourceLanguage()
             print(sourceLanguage)
         }
-    }
-}
-
-// MARK: - Output Helper
-
-private func output<T: Encodable>(_ value: T, pretty: Bool) throws {
-    let encoder = JSONEncoder()
-    if pretty {
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    }
-    let data = try encoder.encode(value)
-    if let json = String(data: data, encoding: .utf8) {
-        print(json)
     }
 }

--- a/Sources/XCStringsCLI/ListCommand.swift
+++ b/Sources/XCStringsCLI/ListCommand.swift
@@ -26,7 +26,7 @@ extension ListCommand {
         func run() async throws {
             let parser = XCStringsParser(path: file)
             let keys = try await parser.listKeys()
-            try output(keys, pretty: pretty)
+            try CLIOutput.printJSON(keys, pretty: pretty)
         }
     }
 
@@ -45,7 +45,7 @@ extension ListCommand {
         func run() async throws {
             let parser = XCStringsParser(path: file)
             let languages = try await parser.listLanguages()
-            try output(languages, pretty: pretty)
+            try CLIOutput.printJSON(languages, pretty: pretty)
         }
     }
 
@@ -67,20 +67,7 @@ extension ListCommand {
         func run() async throws {
             let parser = XCStringsParser(path: file)
             let untranslated = try await parser.listUntranslated(for: lang)
-            try output(untranslated, pretty: pretty)
+            try CLIOutput.printJSON(untranslated, pretty: pretty)
         }
-    }
-}
-
-// MARK: - Output Helper
-
-private func output<T: Encodable>(_ value: T, pretty: Bool) throws {
-    let encoder = JSONEncoder()
-    if pretty {
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    }
-    let data = try encoder.encode(value)
-    if let json = String(data: data, encoding: .utf8) {
-        print(json)
     }
 }

--- a/Sources/XCStringsCLI/RenameCommand.swift
+++ b/Sources/XCStringsCLI/RenameCommand.swift
@@ -34,20 +34,7 @@ extension RenameCommand {
             try await parser.renameKey(from: key, to: to)
 
             let result = CLIResult.success(message: "Key renamed from '\(key)' to '\(to)' successfully")
-            try output(result, pretty: pretty)
+            try CLIOutput.printJSON(result, pretty: pretty)
         }
-    }
-}
-
-// MARK: - Output Helper
-
-private func output<T: Encodable>(_ value: T, pretty: Bool) throws {
-    let encoder = JSONEncoder()
-    if pretty {
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    }
-    let data = try encoder.encode(value)
-    if let json = String(data: data, encoding: .utf8) {
-        print(json)
     }
 }

--- a/Sources/XCStringsCLI/StatsCommand.swift
+++ b/Sources/XCStringsCLI/StatsCommand.swift
@@ -26,7 +26,7 @@ extension StatsCommand {
         func run() async throws {
             let parser = XCStringsParser(path: file)
             let stats = try await parser.getStats()
-            try output(stats, pretty: pretty)
+            try CLIOutput.printJSON(stats, pretty: pretty)
         }
     }
 
@@ -48,20 +48,7 @@ extension StatsCommand {
         func run() async throws {
             let parser = XCStringsParser(path: file)
             let progress = try await parser.getProgress(for: lang)
-            try output(progress, pretty: pretty)
+            try CLIOutput.printJSON(progress, pretty: pretty)
         }
-    }
-}
-
-// MARK: - Output Helper
-
-private func output<T: Encodable>(_ value: T, pretty: Bool) throws {
-    let encoder = JSONEncoder()
-    if pretty {
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    }
-    let data = try encoder.encode(value)
-    if let json = String(data: data, encoding: .utf8) {
-        print(json)
     }
 }

--- a/Sources/XCStringsCLI/UpdateCommand.swift
+++ b/Sources/XCStringsCLI/UpdateCommand.swift
@@ -54,30 +54,20 @@ extension UpdateCommand {
 
         func run() async throws {
             let parser = XCStringsParser(path: file)
+            let result: CLIResult
 
             if !translations.isEmpty {
                 let translationsDict = try TranslationParser.parse(translations)
                 try await parser.updateTranslations(key: key, translations: translationsDict)
-                let result = CLIResult.success(message: "Translations updated successfully for \(translationsDict.count) languages")
-                try output(result, pretty: pretty)
+                result = .success(message: "Translations updated successfully for \(translationsDict.count) languages")
             } else if let lang = lang, let value = value {
                 try await parser.updateTranslation(key: key, language: lang, value: value)
-                let result = CLIResult.success(message: "Translation updated successfully")
-                try output(result, pretty: pretty)
+                result = .success(message: "Translation updated successfully")
+            } else {
+                return
             }
+
+            try CLIOutput.printJSON(result, pretty: pretty)
         }
-    }
-}
-
-// MARK: - Output Helper
-
-private func output<T: Encodable>(_ value: T, pretty: Bool) throws {
-    let encoder = JSONEncoder()
-    if pretty {
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    }
-    let data = try encoder.encode(value)
-    if let json = String(data: data, encoding: .utf8) {
-        print(json)
     }
 }

--- a/Sources/XCStringsKit/TranslationParser.swift
+++ b/Sources/XCStringsKit/TranslationParser.swift
@@ -30,12 +30,27 @@ public enum TranslationParser {
 
         return (lang, value)
     }
+
+    /// Parse JSON string into a translations dictionary
+    /// - Parameter jsonString: JSON string in format `{"lang": "value", ...}`
+    /// - Returns: Dictionary mapping language codes to values
+    /// - Throws: `TranslationParseError.invalidJSON` if JSON is invalid
+    public static func parseJSON(_ jsonString: String) throws -> [String: String] {
+        guard let data = jsonString.data(using: .utf8) else {
+            throw TranslationParseError.invalidJSON(jsonString)
+        }
+        guard let dict = try? JSONDecoder().decode([String: String].self, from: data) else {
+            throw TranslationParseError.invalidJSON(jsonString)
+        }
+        return dict
+    }
 }
 
 /// Errors that can occur when parsing translation input
 public enum TranslationParseError: Error, LocalizedError, Equatable {
     case invalidFormat(String)
     case emptyLanguage(String)
+    case invalidJSON(String)
 
     public var errorDescription: String? {
         switch self {
@@ -43,6 +58,8 @@ public enum TranslationParseError: Error, LocalizedError, Equatable {
             return "Invalid translation format: '\(input)'. Expected 'lang:value'"
         case .emptyLanguage(let input):
             return "Empty language code in: '\(input)'"
+        case .invalidJSON(let input):
+            return "Invalid JSON format: '\(input)'. Expected '{\"lang\": \"value\", ...}'"
         }
     }
 }

--- a/Tests/XCStringsKitTests/TranslationParserTests.swift
+++ b/Tests/XCStringsKitTests/TranslationParserTests.swift
@@ -93,4 +93,50 @@ struct TranslationParserTests {
         #expect(error.errorDescription?.contains(":value") == true)
         #expect(error.errorDescription?.contains("Empty language") == true)
     }
+
+    // MARK: - parseJSON
+
+    @Test("parseJSON converts JSON string to dictionary")
+    func parseJSONValid() throws {
+        let json = #"{"ja":"こんにちは","en":"Hello"}"#
+
+        let result = try TranslationParser.parseJSON(json)
+
+        #expect(result == ["ja": "こんにちは", "en": "Hello"])
+    }
+
+    @Test("parseJSON handles empty object")
+    func parseJSONEmpty() throws {
+        let json = "{}"
+
+        let result = try TranslationParser.parseJSON(json)
+
+        #expect(result.isEmpty)
+    }
+
+    @Test("parseJSON throws for invalid JSON")
+    func parseJSONInvalid() {
+        let json = "not valid json"
+
+        #expect(throws: TranslationParseError.self) {
+            _ = try TranslationParser.parseJSON(json)
+        }
+    }
+
+    @Test("parseJSON throws for non-string values")
+    func parseJSONNonStringValues() {
+        let json = #"{"ja":123}"#
+
+        #expect(throws: TranslationParseError.self) {
+            _ = try TranslationParser.parseJSON(json)
+        }
+    }
+
+    @Test("TranslationParseError.invalidJSON has descriptive message")
+    func errorInvalidJSON() {
+        let error = TranslationParseError.invalidJSON("bad json")
+
+        #expect(error.errorDescription?.contains("bad json") == true)
+        #expect(error.errorDescription?.contains("Invalid JSON") == true)
+    }
 }


### PR DESCRIPTION
## Summary
- Create CLIOutput utility for shared JSON output formatting
- Add parseJSON method to TranslationParser for JSON string parsing
- Remove duplicate output() functions from all 8 command files
- Refactor DeleteCommand.run() and UpdateCommand.run() for cleaner code

## Changes
- **New**: Sources/XCStringsCLI/CLIOutput.swift - Shared JSON output utility
- **New**: TranslationParser.parseJSON() - JSON string parsing method
- **Modified**: Removed duplicate code from 8 command files
- **New Tests**: 5 unit tests for parseJSON functionality

## Test plan
- [x] swift build succeeds
- [x] swift test - All 102 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)