### PR TITLE
Unify translations format: use -t lang:value for add command

### DIFF
--- a/Sources/XCStringsKit/TranslationParser.swift
+++ b/Sources/XCStringsKit/TranslationParser.swift
@@ -31,26 +31,12 @@ public enum TranslationParser {
         return (lang, value)
     }
 
-    /// Parse JSON string into a translations dictionary
-    /// - Parameter jsonString: JSON string in format `{"lang": "value", ...}`
-    /// - Returns: Dictionary mapping language codes to values
-    /// - Throws: `TranslationParseError.invalidJSON` if JSON is invalid
-    public static func parseJSON(_ jsonString: String) throws -> [String: String] {
-        guard let data = jsonString.data(using: .utf8) else {
-            throw TranslationParseError.invalidJSON(jsonString)
-        }
-        guard let dict = try? JSONDecoder().decode([String: String].self, from: data) else {
-            throw TranslationParseError.invalidJSON(jsonString)
-        }
-        return dict
-    }
 }
 
 /// Errors that can occur when parsing translation input
 public enum TranslationParseError: Error, LocalizedError, Equatable {
     case invalidFormat(String)
     case emptyLanguage(String)
-    case invalidJSON(String)
 
     public var errorDescription: String? {
         switch self {
@@ -58,8 +44,6 @@ public enum TranslationParseError: Error, LocalizedError, Equatable {
             return "Invalid translation format: '\(input)'. Expected 'lang:value'"
         case .emptyLanguage(let input):
             return "Empty language code in: '\(input)'"
-        case .invalidJSON(let input):
-            return "Invalid JSON format: '\(input)'. Expected '{\"lang\": \"value\", ...}'"
         }
     }
 }

--- a/Tests/XCStringsKitTests/TranslationParserTests.swift
+++ b/Tests/XCStringsKitTests/TranslationParserTests.swift
@@ -94,49 +94,4 @@ struct TranslationParserTests {
         #expect(error.errorDescription?.contains("Empty language") == true)
     }
 
-    // MARK: - parseJSON
-
-    @Test("parseJSON converts JSON string to dictionary")
-    func parseJSONValid() throws {
-        let json = #"{"ja":"こんにちは","en":"Hello"}"#
-
-        let result = try TranslationParser.parseJSON(json)
-
-        #expect(result == ["ja": "こんにちは", "en": "Hello"])
-    }
-
-    @Test("parseJSON handles empty object")
-    func parseJSONEmpty() throws {
-        let json = "{}"
-
-        let result = try TranslationParser.parseJSON(json)
-
-        #expect(result.isEmpty)
-    }
-
-    @Test("parseJSON throws for invalid JSON")
-    func parseJSONInvalid() {
-        let json = "not valid json"
-
-        #expect(throws: TranslationParseError.self) {
-            _ = try TranslationParser.parseJSON(json)
-        }
-    }
-
-    @Test("parseJSON throws for non-string values")
-    func parseJSONNonStringValues() {
-        let json = #"{"ja":123}"#
-
-        #expect(throws: TranslationParseError.self) {
-            _ = try TranslationParser.parseJSON(json)
-        }
-    }
-
-    @Test("TranslationParseError.invalidJSON has descriptive message")
-    func errorInvalidJSON() {
-        let error = TranslationParseError.invalidJSON("bad json")
-
-        #expect(error.errorDescription?.contains("bad json") == true)
-        #expect(error.errorDescription?.contains("Invalid JSON") == true)
-    }
 }


### PR DESCRIPTION
## Summary

- Unify AddCommand interface to use `-t lang:value` format (same as UpdateCommand)
- Remove unused JSON parsing functionality from TranslationParser

## Changes

- `AddCommand`: Changed from `--translations JSON` to `-t lang:value` format
- `TranslationParser`: Removed `parseJSON` method
- `TranslationParseError`: Removed `invalidJSON` case
- Removed 5 parseJSON related tests

## Usage

```bash
# Before (JSON format)
xcstrings-crud add key "Hello" -f test.xcstrings --translations '{"ja":"こんにちは","en":"Hello"}'

# After (lang:value format, same as update command)
xcstrings-crud add key "Hello" -f test.xcstrings -t ja:こんにちは en:Hello
```

## Test

All 97 tests pass.