### PR TITLE
Add batch stats coverage for multiple xcstrings files

### DIFF
--- a/Sources/XCStringsKit/Models/XCStrings.swift
+++ b/Sources/XCStringsKit/Models/XCStrings.swift
@@ -186,3 +186,40 @@ package struct LanguageStats: Codable, Sendable {
         self.coveragePercent = coveragePercent
     }
 }
+
+/// Token-efficient batch coverage summary for multiple files
+package struct BatchCoverageSummary: Codable, Sendable {
+    package let files: [FileCoverageSummary]
+    package let aggregated: AggregatedCoverage
+
+    package init(files: [FileCoverageSummary], aggregated: AggregatedCoverage) {
+        self.files = files
+        self.aggregated = aggregated
+    }
+}
+
+/// Compact coverage summary for a single file
+package struct FileCoverageSummary: Codable, Sendable {
+    package let file: String
+    package let totalKeys: Int
+    package let languages: [String: Double]  // lang -> coveragePercent
+
+    package init(file: String, totalKeys: Int, languages: [String: Double]) {
+        self.file = file
+        self.totalKeys = totalKeys
+        self.languages = languages
+    }
+}
+
+/// Aggregated coverage across all files
+package struct AggregatedCoverage: Codable, Sendable {
+    package let totalFiles: Int
+    package let totalKeys: Int
+    package let averageCoverageByLanguage: [String: Double]
+
+    package init(totalFiles: Int, totalKeys: Int, averageCoverageByLanguage: [String: Double]) {
+        self.totalFiles = totalFiles
+        self.totalKeys = totalKeys
+        self.averageCoverageByLanguage = averageCoverageByLanguage
+    }
+}

--- a/Sources/XCStringsKit/XCStringsParser.swift
+++ b/Sources/XCStringsKit/XCStringsParser.swift
@@ -85,6 +85,16 @@ package actor XCStringsParser {
         return try XCStringsStatsCalculator(file: file).getProgress(for: language)
     }
 
+    /// Get batch coverage for multiple files (token-efficient)
+    package static func getBatchCoverage(paths: [String]) throws -> BatchCoverageSummary {
+        let files: [(path: String, file: XCStringsFile)] = try paths.map { path in
+            let handler = XCStringsFileHandler(path: path)
+            let file = try handler.load()
+            return (path, file)
+        }
+        return XCStringsStatsCalculator.getBatchCoverage(files: files)
+    }
+
     // MARK: - Write Operations
 
     /// Add a translation


### PR DESCRIPTION
## Summary

Add token-efficient batch coverage statistics for multiple xcstrings files.

## Features

- **New Models**: `BatchCoverageSummary`, `FileCoverageSummary`, `AggregatedCoverage`
- **New API**: `XCStringsParser.getBatchCoverage(paths:)` static method
- **New MCP Tool**: `xcstrings_batch_stats_coverage`
- **New CLI Command**: `stats batch-coverage`

## Output Format

Returns compact coverage percentages per language for each file plus aggregated totals:

```json
{
  "aggregated": {
    "totalFiles": 31,
    "totalKeys": 579,
    "averageCoverageByLanguage": { "en": 100, "ja": 100, ... }
  },
  "files": [
    { "file": "path/to/file.xcstrings", "totalKeys": 28, "languages": { "en": 100, "ja": 100 } }
  ]
}
```

## Usage

```bash
# CLI
xcstrings-crud stats batch-coverage -f file1.xcstrings file2.xcstrings --pretty

# MCP tool
xcstrings_batch_stats_coverage with { "files": ["file1.xcstrings", "file2.xcstrings"] }
```

## Test

All 97 tests pass.