### PR TITLE
Add compact coverage output to show only incomplete languages

### DIFF
--- a/Sources/XCStringsCLI/StatsCommand.swift
+++ b/Sources/XCStringsCLI/StatsCommand.swift
@@ -23,10 +23,18 @@ extension StatsCommand {
         @Flag(name: .long, help: "Output in pretty-printed JSON format")
         var pretty = false
 
+        @Flag(name: .long, help: "Compact output: only show languages under 100%")
+        var compact = false
+
         func run() async throws {
             let parser = XCStringsParser(path: file)
-            let stats = try await parser.getStats()
-            try CLIOutput.printJSON(stats, pretty: pretty)
+            if compact {
+                let stats = try await parser.getCompactStats()
+                try CLIOutput.printJSON(stats, pretty: pretty)
+            } else {
+                let stats = try await parser.getStats()
+                try CLIOutput.printJSON(stats, pretty: pretty)
+            }
         }
     }
 
@@ -64,6 +72,9 @@ extension StatsCommand {
         @Flag(name: .long, help: "Output in pretty-printed JSON format")
         var pretty = false
 
+        @Flag(name: .long, help: "Compact output: only show languages under 100%")
+        var compact = false
+
         func validate() throws {
             if files.isEmpty {
                 throw ValidationError("At least one file path must be specified")
@@ -71,8 +82,13 @@ extension StatsCommand {
         }
 
         func run() async throws {
-            let batchCoverage = try XCStringsParser.getBatchCoverage(paths: files)
-            try CLIOutput.printJSON(batchCoverage, pretty: pretty)
+            if compact {
+                let batchCoverage = try XCStringsParser.getCompactBatchCoverage(paths: files)
+                try CLIOutput.printJSON(batchCoverage, pretty: pretty)
+            } else {
+                let batchCoverage = try XCStringsParser.getBatchCoverage(paths: files)
+                try CLIOutput.printJSON(batchCoverage, pretty: pretty)
+            }
         }
     }
 }

--- a/Sources/XCStringsKit/XCStringsParser.swift
+++ b/Sources/XCStringsKit/XCStringsParser.swift
@@ -95,6 +95,24 @@ package actor XCStringsParser {
         return XCStringsStatsCalculator.getBatchCoverage(files: files)
     }
 
+    // MARK: - Compact Stats Operations (100% languages omitted)
+
+    /// Get compact statistics (only shows incomplete languages)
+    package func getCompactStats() throws -> CompactStatsInfo {
+        let file = try load()
+        return XCStringsStatsCalculator(file: file).getCompactStats()
+    }
+
+    /// Get compact batch coverage for multiple files
+    package static func getCompactBatchCoverage(paths: [String]) throws -> CompactBatchCoverageSummary {
+        let files: [(path: String, file: XCStringsFile)] = try paths.map { path in
+            let handler = XCStringsFileHandler(path: path)
+            let file = try handler.load()
+            return (path, file)
+        }
+        return XCStringsStatsCalculator.getCompactBatchCoverage(files: files)
+    }
+
     // MARK: - Write Operations
 
     /// Add a translation

--- a/Sources/XCStringsKit/XCStringsStatsCalculator.swift
+++ b/Sources/XCStringsKit/XCStringsStatsCalculator.swift
@@ -101,4 +101,16 @@ struct XCStringsStatsCalculator: Sendable {
             )
         )
     }
+
+    // MARK: - Compact Output (100% languages omitted)
+
+    /// Get compact stats (only shows incomplete languages)
+    func getCompactStats() -> CompactStatsInfo {
+        CompactStatsInfo(from: getStats())
+    }
+
+    /// Get compact batch coverage for multiple files
+    static func getCompactBatchCoverage(files: [(path: String, file: XCStringsFile)]) -> CompactBatchCoverageSummary {
+        CompactBatchCoverageSummary(from: getBatchCoverage(files: files))
+    }
 }


### PR DESCRIPTION
## Summary
- Add compact coverage output mode that only shows languages under 100% coverage
- 100% languages are summarized with `completeCount` instead of showing full details
- When all languages are 100%, `allComplete: true` and `incompleteLanguages` is omitted

## Changes
- **New models**: `CompactStatsInfo`, `CompactFileCoverageSummary`, `CompactBatchCoverageSummary`, `CompactAggregatedCoverage`
- **CLI**: Add `--compact` flag to `stats coverage` and `stats batch-coverage` commands
- **MCP**: Add `compact` parameter (default: `true`) to `xcstrings_stats_coverage` and `xcstrings_batch_stats_coverage` tools

## Example Output

### Incomplete languages exist
```json
{
  "allComplete": false,
  "completeCount": 1,
  "totalLanguages": 3,
  "incompleteLanguages": {
    "ja": { "coveragePercent": 66.67, ... },
    "fr": { "coveragePercent": 33.33, ... }
  }
}
```

### All languages complete
```json
{
  "allComplete": true,
  "completeCount": 2,
  "totalLanguages": 2
}
```

## Test plan
- [x] Unit tests pass
- [x] Manual testing with `--compact` flag
- [x] Verified all 100% case shows `allComplete: true`
- [x] Verified incomplete case shows only languages under 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)