### PR TITLE
Add create command to generate new xcstrings files

### DIFF
--- a/Sources/XCStringsCLI/CreateCommand.swift
+++ b/Sources/XCStringsCLI/CreateCommand.swift
@@ -1,0 +1,28 @@
+import ArgumentParser
+import Foundation
+import XCStringsKit
+
+struct CreateCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "create",
+        abstract: "Create a new xcstrings file"
+    )
+
+    @Argument(help: "Path for the new xcstrings file")
+    var file: String
+
+    @Option(name: .shortAndLong, help: "Source language code (default: en)")
+    var sourceLanguage: String = "en"
+
+    @Flag(name: .long, help: "Overwrite existing file if it exists")
+    var overwrite = false
+
+    @Flag(name: .long, help: "Output in pretty-printed JSON format")
+    var pretty = false
+
+    func run() async throws {
+        try XCStringsParser.createFile(at: file, sourceLanguage: sourceLanguage, overwrite: overwrite)
+        let result = CLIResult.success(message: "Created xcstrings file at '\(file)' with source language '\(sourceLanguage)'")
+        try CLIOutput.printJSON(result, pretty: pretty)
+    }
+}

--- a/Sources/XCStringsCLI/XCStringsCLI.swift
+++ b/Sources/XCStringsCLI/XCStringsCLI.swift
@@ -7,6 +7,7 @@ public struct XCStringsCLI: AsyncParsableCommand {
         abstract: "A CLI tool for CRUD operations on xcstrings files",
         version: "1.0.0",
         subcommands: [
+            CreateCommand.self,
             ListCommand.self,
             GetCommand.self,
             CheckCommand.self,

--- a/Sources/XCStringsKit/Errors.swift
+++ b/Sources/XCStringsKit/Errors.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Errors thrown by XCStringsKit
 package enum XCStringsError: Error, LocalizedError, Sendable {
     case fileNotFound(path: String)
+    case fileAlreadyExists(path: String)
     case invalidFileFormat(path: String, reason: String)
     case keyNotFound(key: String)
     case keyAlreadyExists(key: String)
@@ -14,6 +15,8 @@ package enum XCStringsError: Error, LocalizedError, Sendable {
         switch self {
         case let .fileNotFound(path):
             return "File not found: \(path)"
+        case let .fileAlreadyExists(path):
+            return "File already exists: \(path)"
         case let .invalidFileFormat(path, reason):
             return "Invalid file format at '\(path)': \(reason)"
         case let .keyNotFound(key):

--- a/Sources/XCStringsKit/XCStringsFileHandler.swift
+++ b/Sources/XCStringsKit/XCStringsFileHandler.swift
@@ -50,4 +50,30 @@ struct XCStringsFileHandler: Sendable {
             throw XCStringsError.writeError(path: path, reason: error.localizedDescription)
         }
     }
+
+    /// Create a new xcstrings file
+    func create(sourceLanguage: String, overwrite: Bool = false) throws {
+        let url = URL(fileURLWithPath: path)
+
+        if !overwrite && FileManager.default.fileExists(atPath: path) {
+            throw XCStringsError.fileAlreadyExists(path: path)
+        }
+
+        let file = XCStringsFile(sourceLanguage: sourceLanguage)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        let data: Data
+        do {
+            data = try encoder.encode(file)
+        } catch {
+            throw XCStringsError.writeError(path: path, reason: error.localizedDescription)
+        }
+
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch {
+            throw XCStringsError.writeError(path: path, reason: error.localizedDescription)
+        }
+    }
 }

--- a/Sources/XCStringsKit/XCStringsParser.swift
+++ b/Sources/XCStringsKit/XCStringsParser.swift
@@ -21,6 +21,17 @@ package actor XCStringsParser {
         try fileHandler.save(file)
     }
 
+    /// Create a new xcstrings file
+    package func createFile(sourceLanguage: String, overwrite: Bool = false) throws {
+        try fileHandler.create(sourceLanguage: sourceLanguage, overwrite: overwrite)
+    }
+
+    /// Create a new xcstrings file (static version for convenience)
+    package static func createFile(at path: String, sourceLanguage: String, overwrite: Bool = false) throws {
+        let handler = XCStringsFileHandler(path: path)
+        try handler.create(sourceLanguage: sourceLanguage, overwrite: overwrite)
+    }
+
     // MARK: - Read Operations
 
     /// Get all keys sorted alphabetically

--- a/Sources/XCStringsMCP/MCPServer.swift
+++ b/Sources/XCStringsMCP/MCPServer.swift
@@ -153,6 +153,20 @@ public struct XCStringsMCPServer {
                     "required": .array([.string("files")]),
                 ])
             ),
+            // Create operations
+            Tool(
+                name: "xcstrings_create_file",
+                description: "Create a new xcstrings file with the specified source language",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "file": .object(["type": .string("string"), "description": .string("Path for the new xcstrings file")]),
+                        "sourceLanguage": .object(["type": .string("string"), "description": .string("Source language code (default: en)")]),
+                        "overwrite": .object(["type": .string("boolean"), "description": .string("Overwrite existing file if it exists (default: false)")]),
+                    ]),
+                    "required": .array([.string("file")]),
+                ])
+            ),
             // Write operations
             Tool(
                 name: "xcstrings_add_translation",
@@ -297,6 +311,14 @@ public struct XCStringsMCPServer {
 
         guard let file = args["file"]?.stringValue else {
             throw XCStringsError.invalidJSON(reason: "Missing 'file' parameter")
+        }
+
+        // Handle create operation (doesn't need existing file)
+        if params.name == "xcstrings_create_file" {
+            let sourceLanguage = args["sourceLanguage"]?.stringValue ?? "en"
+            let overwrite = args["overwrite"]?.boolValue ?? false
+            try XCStringsParser.createFile(at: file, sourceLanguage: sourceLanguage, overwrite: overwrite)
+            return "Created xcstrings file at '\(file)' with source language '\(sourceLanguage)'"
         }
 
         let parser = XCStringsParser(path: file)


### PR DESCRIPTION
## Summary
- Add ability to create new empty xcstrings files with a specified source language
- Supports both CLI and MCP interfaces

## Changes
- **XCStringsFileHandler**: Add `create()` method for file creation
- **XCStringsParser**: Add `createFile()` facade methods (instance and static)
- **Errors**: Add `fileAlreadyExists` error case
- **CLI**: Add `create` command
- **MCP**: Add `xcstrings_create_file` tool

## Usage

### CLI
```bash
# Create with default source language (en)
xcstrings-crud create path/to/Localizable.xcstrings

# Create with custom source language
xcstrings-crud create path/to/Localizable.xcstrings -s ja

# Overwrite existing file
xcstrings-crud create path/to/Localizable.xcstrings --overwrite
```

### MCP
```json
{
  "file": "path/to/Localizable.xcstrings",
  "sourceLanguage": "ja",
  "overwrite": false
}
```

## Test plan
- [x] Unit tests pass
- [x] CLI create command works with default options
- [x] CLI create command works with custom source language
- [x] Error is thrown when file already exists
- [x] Overwrite flag allows replacing existing file

🤖 Generated with [Claude Code](https://claude.com/claude-code)