### PR TITLE
Add list stale keys feature

### DIFF
--- a/Sources/XCStringsCLI/ListCommand.swift
+++ b/Sources/XCStringsCLI/ListCommand.swift
@@ -5,8 +5,8 @@ import XCStringsKit
 struct ListCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "list",
-        abstract: "List keys, languages, or untranslated items",
-        subcommands: [Keys.self, Languages.self, Untranslated.self]
+        abstract: "List keys, languages, untranslated, or stale items",
+        subcommands: [Keys.self, Languages.self, Untranslated.self, Stale.self]
     )
 }
 
@@ -68,6 +68,25 @@ extension ListCommand {
             let parser = XCStringsParser(path: file)
             let untranslated = try await parser.listUntranslated(for: lang)
             try CLIOutput.printJSON(untranslated, pretty: pretty)
+        }
+    }
+
+    struct Stale: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "stale",
+            abstract: "List keys with stale extraction state (potentially unused)"
+        )
+
+        @Option(name: .shortAndLong, help: "Path to the xcstrings file")
+        var file: String
+
+        @Flag(name: .long, help: "Output in pretty-printed JSON format")
+        var pretty = false
+
+        func run() async throws {
+            let parser = XCStringsParser(path: file)
+            let staleKeys = try await parser.listStaleKeys()
+            try CLIOutput.printJSON(staleKeys, pretty: pretty)
         }
     }
 }

--- a/Sources/XCStringsKit/XCStringsParser.swift
+++ b/Sources/XCStringsKit/XCStringsParser.swift
@@ -52,6 +52,12 @@ package actor XCStringsParser {
         return XCStringsReader(file: file).listUntranslated(for: language)
     }
 
+    /// Get keys with stale extraction state
+    package func listStaleKeys() throws -> [String] {
+        let file = try load()
+        return XCStringsReader(file: file).listStaleKeys()
+    }
+
     /// Get source language
     package func getSourceLanguage() throws -> String {
         let file = try load()

--- a/Sources/XCStringsKit/XCStringsReader.swift
+++ b/Sources/XCStringsKit/XCStringsReader.swift
@@ -43,6 +43,14 @@ struct XCStringsReader: Sendable {
         return untranslated.sorted()
     }
 
+    /// Get keys with stale extraction state
+    func listStaleKeys() -> [String] {
+        file.strings
+            .filter { $0.value.extractionState == "stale" }
+            .map { $0.key }
+            .sorted()
+    }
+
     /// Get source language
     func getSourceLanguage() -> String {
         file.sourceLanguage

--- a/Tests/XCStringsKitTests/FixtureType.swift
+++ b/Tests/XCStringsKitTests/FixtureType.swift
@@ -16,6 +16,7 @@ enum FixtureType: String, CaseIterable, CustomTestStringConvertible {
     case emptyLocalizations
     case manyLanguages
     case variousStates
+    case withStaleKeys
 
     var testDescription: String { rawValue }
 
@@ -32,6 +33,7 @@ enum FixtureType: String, CaseIterable, CustomTestStringConvertible {
         case .emptyLocalizations: TestFixtures.emptyLocalizations
         case .manyLanguages: TestFixtures.manyLanguages
         case .variousStates: TestFixtures.variousStates
+        case .withStaleKeys: TestFixtures.withStaleKeys
         }
     }
 
@@ -48,6 +50,7 @@ enum FixtureType: String, CaseIterable, CustomTestStringConvertible {
         case .emptyLocalizations: 2
         case .manyLanguages: 1
         case .variousStates: 3
+        case .withStaleKeys: 4
         }
     }
 

--- a/Tests/XCStringsKitTests/ListOperationsTests.swift
+++ b/Tests/XCStringsKitTests/ListOperationsTests.swift
@@ -59,4 +59,38 @@ struct ListOperationsTests {
 
         #expect(untranslated == expectedKeys)
     }
+
+    @Test("listStaleKeys returns keys with stale extraction state")
+    func listStaleKeys() async throws {
+        let path = try TestHelper.createTempFile(content: TestFixtures.withStaleKeys)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let staleKeys = try await parser.listStaleKeys()
+
+        #expect(staleKeys == ["StaleKey1", "StaleKey2"])
+    }
+
+    @Test("listStaleKeys returns empty array when no stale keys")
+    func listStaleKeysEmpty() async throws {
+        let path = try TestHelper.createTempFile(content: TestFixtures.singleKeySingleLang)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let staleKeys = try await parser.listStaleKeys()
+
+        #expect(staleKeys.isEmpty)
+    }
+
+    @Test("listStaleKeys ignores other extraction states")
+    func listStaleKeysIgnoresOtherStates() async throws {
+        let path = try TestHelper.createTempFile(content: TestFixtures.withComments)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let staleKeys = try await parser.listStaleKeys()
+
+        // withComments has "manual" extraction state, not "stale"
+        #expect(staleKeys.isEmpty)
+    }
 }

--- a/Tests/XCStringsKitTests/TestFixtures.swift
+++ b/Tests/XCStringsKitTests/TestFixtures.swift
@@ -316,6 +316,40 @@ enum TestFixtures {
       "version": "1.0"
     }
     """
+
+    /// Keys with stale extraction state
+    static let withStaleKeys = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "ActiveKey": {
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Active" } }
+          }
+        },
+        "StaleKey1": {
+          "extractionState": "stale",
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Stale 1" } }
+          }
+        },
+        "StaleKey2": {
+          "extractionState": "stale",
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Stale 2" } },
+            "ja": { "stringUnit": { "state": "translated", "value": "古い2" } }
+          }
+        },
+        "ManualKey": {
+          "extractionState": "manual",
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Manual" } }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
 }
 
 /// Test helper utilities


### PR DESCRIPTION
## Summary
- Add `listStaleKeys()` method to detect keys with `extractionState: "stale"`
- Add `list stale` CLI subcommand for listing potentially unused keys
- Add `xcstrings_list_stale` MCP tool with verification guidance note

## Details
Xcode marks keys as "stale" when they are no longer found in source code during extraction. This feature allows users to identify these potentially unused keys.

The MCP tool includes a note reminding users to verify if keys are truly unused by searching the module/project source code before deletion.

## Test plan
- [x] Unit tests for `listStaleKeys()` method
- [x] Test for empty result when no stale keys exist
- [x] Test that other extraction states (e.g., "manual") are ignored
- [x] All 100 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)