### PR TITLE
Add batch operations for multiple keys

### DIFF
--- a/Sources/XCStringsCLI/BatchCommand.swift
+++ b/Sources/XCStringsCLI/BatchCommand.swift
@@ -1,0 +1,185 @@
+import ArgumentParser
+import Foundation
+import XCStringsKit
+
+struct BatchCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "batch",
+        abstract: "Batch operations for multiple keys",
+        subcommands: [Check.self, Add.self, Update.self]
+    )
+}
+
+extension BatchCommand {
+    struct Check: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "check",
+            abstract: "Check if multiple keys exist"
+        )
+
+        @Option(name: .shortAndLong, parsing: .upToNextOption, help: "Keys to check")
+        var keys: [String]
+
+        @Option(name: .shortAndLong, help: "Path to the xcstrings file")
+        var file: String
+
+        @Option(name: .shortAndLong, help: "Specific language to check (optional)")
+        var lang: String?
+
+        @Flag(name: .long, help: "Output in pretty-printed JSON format")
+        var pretty = false
+
+        func validate() throws {
+            if keys.isEmpty {
+                throw ValidationError("At least one key must be specified")
+            }
+        }
+
+        func run() async throws {
+            let parser = XCStringsParser(path: file)
+            let result = try await parser.checkKeys(keys, language: lang)
+            try CLIOutput.printJSON(result, pretty: pretty)
+        }
+    }
+
+    struct Add: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "add",
+            abstract: "Add translations for multiple keys at once"
+        )
+
+        @Option(name: .shortAndLong, help: "Path to the xcstrings file")
+        var file: String
+
+        @Option(name: .shortAndLong, parsing: .upToNextOption, help: "Entries in key=lang:value,lang:value format (e.g., -e Hello=ja:こんにちは,en:Hello -e Goodbye=ja:さようなら)")
+        var entries: [String]
+
+        @Flag(name: .long, help: "Allow overwriting existing translations")
+        var overwrite = false
+
+        @Flag(name: .long, help: "Output in pretty-printed JSON format")
+        var pretty = false
+
+        func validate() throws {
+            if entries.isEmpty {
+                throw ValidationError("At least one entry must be specified")
+            }
+        }
+
+        func run() async throws {
+            let parser = XCStringsParser(path: file)
+            let batchEntries = try parseEntries(entries)
+            let result = try await parser.addTranslationsBatch(entries: batchEntries, allowOverwrite: overwrite)
+            try CLIOutput.printJSON(result, pretty: pretty)
+        }
+
+        private func parseEntries(_ inputs: [String]) throws -> [BatchTranslationEntry] {
+            try inputs.map { input in
+                try BatchEntryParser.parse(input)
+            }
+        }
+    }
+
+    struct Update: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "update",
+            abstract: "Update translations for multiple keys at once"
+        )
+
+        @Option(name: .shortAndLong, help: "Path to the xcstrings file")
+        var file: String
+
+        @Option(name: .shortAndLong, parsing: .upToNextOption, help: "Entries in key=lang:value,lang:value format (e.g., -e Hello=ja:こんにちは,en:Hello -e Goodbye=ja:さようなら)")
+        var entries: [String]
+
+        @Flag(name: .long, help: "Output in pretty-printed JSON format")
+        var pretty = false
+
+        func validate() throws {
+            if entries.isEmpty {
+                throw ValidationError("At least one entry must be specified")
+            }
+        }
+
+        func run() async throws {
+            let parser = XCStringsParser(path: file)
+            let batchEntries = try parseEntries(entries)
+            let result = try await parser.updateTranslationsBatch(entries: batchEntries)
+            try CLIOutput.printJSON(result, pretty: pretty)
+        }
+
+        private func parseEntries(_ inputs: [String]) throws -> [BatchTranslationEntry] {
+            try inputs.map { input in
+                try BatchEntryParser.parse(input)
+            }
+        }
+    }
+}
+
+/// Parser for batch entry format
+enum BatchEntryParser {
+    /// Parse "key=lang:value,lang:value" format
+    /// Example: "Hello=ja:こんにちは,en:Hello"
+    static func parse(_ input: String) throws -> BatchTranslationEntry {
+        guard let equalsIndex = input.firstIndex(of: "=") else {
+            throw BatchEntryParseError.invalidFormat(input)
+        }
+
+        let key = String(input[..<equalsIndex])
+        let translationsStr = String(input[input.index(after: equalsIndex)...])
+
+        guard !key.isEmpty else {
+            throw BatchEntryParseError.emptyKey(input)
+        }
+
+        // Parse translations (comma-separated lang:value pairs)
+        let pairs = translationsStr.split(separator: ",", omittingEmptySubsequences: false)
+        var translations: [String: String] = [:]
+
+        for pair in pairs {
+            let pairStr = String(pair)
+            guard let colonIndex = pairStr.firstIndex(of: ":") else {
+                throw BatchEntryParseError.invalidTranslationFormat(pairStr)
+            }
+
+            let lang = String(pairStr[..<colonIndex])
+            let value = String(pairStr[pairStr.index(after: colonIndex)...])
+
+            guard !lang.isEmpty else {
+                throw BatchEntryParseError.emptyLanguage(pairStr)
+            }
+
+            translations[lang] = value
+        }
+
+        if translations.isEmpty {
+            throw BatchEntryParseError.noTranslations(input)
+        }
+
+        return BatchTranslationEntry(key: key, translations: translations)
+    }
+}
+
+/// Errors for batch entry parsing
+enum BatchEntryParseError: Error, LocalizedError {
+    case invalidFormat(String)
+    case emptyKey(String)
+    case invalidTranslationFormat(String)
+    case emptyLanguage(String)
+    case noTranslations(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidFormat(let input):
+            return "Invalid batch entry format: '\(input)'. Expected 'key=lang:value,lang:value'"
+        case .emptyKey(let input):
+            return "Empty key in: '\(input)'"
+        case .invalidTranslationFormat(let input):
+            return "Invalid translation format: '\(input)'. Expected 'lang:value'"
+        case .emptyLanguage(let input):
+            return "Empty language code in: '\(input)'"
+        case .noTranslations(let input):
+            return "No translations specified for: '\(input)'"
+        }
+    }
+}

--- a/Sources/XCStringsCLI/BatchCommand.swift
+++ b/Sources/XCStringsCLI/BatchCommand.swift
@@ -68,15 +68,9 @@ extension BatchCommand {
 
         func run() async throws {
             let parser = XCStringsParser(path: file)
-            let batchEntries = try parseEntries(entries)
+            let batchEntries = try entries.map { try BatchEntryParser.parse($0) }
             let result = try await parser.addTranslationsBatch(entries: batchEntries, allowOverwrite: overwrite)
             try CLIOutput.printJSON(result, pretty: pretty)
-        }
-
-        private func parseEntries(_ inputs: [String]) throws -> [BatchTranslationEntry] {
-            try inputs.map { input in
-                try BatchEntryParser.parse(input)
-            }
         }
     }
 
@@ -103,83 +97,9 @@ extension BatchCommand {
 
         func run() async throws {
             let parser = XCStringsParser(path: file)
-            let batchEntries = try parseEntries(entries)
+            let batchEntries = try entries.map { try BatchEntryParser.parse($0) }
             let result = try await parser.updateTranslationsBatch(entries: batchEntries)
             try CLIOutput.printJSON(result, pretty: pretty)
-        }
-
-        private func parseEntries(_ inputs: [String]) throws -> [BatchTranslationEntry] {
-            try inputs.map { input in
-                try BatchEntryParser.parse(input)
-            }
-        }
-    }
-}
-
-/// Parser for batch entry format
-enum BatchEntryParser {
-    /// Parse "key=lang:value,lang:value" format
-    /// Example: "Hello=ja:こんにちは,en:Hello"
-    static func parse(_ input: String) throws -> BatchTranslationEntry {
-        guard let equalsIndex = input.firstIndex(of: "=") else {
-            throw BatchEntryParseError.invalidFormat(input)
-        }
-
-        let key = String(input[..<equalsIndex])
-        let translationsStr = String(input[input.index(after: equalsIndex)...])
-
-        guard !key.isEmpty else {
-            throw BatchEntryParseError.emptyKey(input)
-        }
-
-        // Parse translations (comma-separated lang:value pairs)
-        let pairs = translationsStr.split(separator: ",", omittingEmptySubsequences: false)
-        var translations: [String: String] = [:]
-
-        for pair in pairs {
-            let pairStr = String(pair)
-            guard let colonIndex = pairStr.firstIndex(of: ":") else {
-                throw BatchEntryParseError.invalidTranslationFormat(pairStr)
-            }
-
-            let lang = String(pairStr[..<colonIndex])
-            let value = String(pairStr[pairStr.index(after: colonIndex)...])
-
-            guard !lang.isEmpty else {
-                throw BatchEntryParseError.emptyLanguage(pairStr)
-            }
-
-            translations[lang] = value
-        }
-
-        if translations.isEmpty {
-            throw BatchEntryParseError.noTranslations(input)
-        }
-
-        return BatchTranslationEntry(key: key, translations: translations)
-    }
-}
-
-/// Errors for batch entry parsing
-enum BatchEntryParseError: Error, LocalizedError {
-    case invalidFormat(String)
-    case emptyKey(String)
-    case invalidTranslationFormat(String)
-    case emptyLanguage(String)
-    case noTranslations(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .invalidFormat(let input):
-            return "Invalid batch entry format: '\(input)'. Expected 'key=lang:value,lang:value'"
-        case .emptyKey(let input):
-            return "Empty key in: '\(input)'"
-        case .invalidTranslationFormat(let input):
-            return "Invalid translation format: '\(input)'. Expected 'lang:value'"
-        case .emptyLanguage(let input):
-            return "Empty language code in: '\(input)'"
-        case .noTranslations(let input):
-            return "No translations specified for: '\(input)'"
         }
     }
 }

--- a/Sources/XCStringsCLI/XCStringsCLI.swift
+++ b/Sources/XCStringsCLI/XCStringsCLI.swift
@@ -16,6 +16,7 @@ public struct XCStringsCLI: AsyncParsableCommand {
             DeleteCommand.self,
             RenameCommand.self,
             StatsCommand.self,
+            BatchCommand.self,
             MCPCommand.self,
         ]
     )

--- a/Sources/XCStringsKit/BatchEntryParser.swift
+++ b/Sources/XCStringsKit/BatchEntryParser.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Parser for batch entry format
+package enum BatchEntryParser {
+    /// Parse "key=lang:value,lang:value" format
+    /// Example: "Hello=ja:こんにちは,en:Hello"
+    package static func parse(_ input: String) throws -> BatchTranslationEntry {
+        guard let equalsIndex = input.firstIndex(of: "=") else {
+            throw BatchEntryParseError.invalidFormat(input)
+        }
+
+        let key = String(input[..<equalsIndex])
+        let translationsStr = String(input[input.index(after: equalsIndex)...])
+
+        guard !key.isEmpty else {
+            throw BatchEntryParseError.emptyKey(input)
+        }
+
+        // Parse translations (comma-separated lang:value pairs)
+        let translations = try translationsStr
+            .split(separator: ",", omittingEmptySubsequences: false)
+            .reduce(into: [String: String]()) { result, pair in
+                let pairStr = String(pair)
+                guard let colonIndex = pairStr.firstIndex(of: ":") else {
+                    throw BatchEntryParseError.invalidTranslationFormat(pairStr)
+                }
+
+                let lang = String(pairStr[..<colonIndex])
+                let value = String(pairStr[pairStr.index(after: colonIndex)...])
+
+                guard !lang.isEmpty else {
+                    throw BatchEntryParseError.emptyLanguage(pairStr)
+                }
+
+                result[lang] = value
+            }
+
+        if translations.isEmpty {
+            throw BatchEntryParseError.noTranslations(input)
+        }
+
+        return BatchTranslationEntry(key: key, translations: translations)
+    }
+}
+
+/// Errors for batch entry parsing
+package enum BatchEntryParseError: Error, LocalizedError {
+    case invalidFormat(String)
+    case emptyKey(String)
+    case invalidTranslationFormat(String)
+    case emptyLanguage(String)
+    case noTranslations(String)
+
+    package var errorDescription: String? {
+        switch self {
+        case .invalidFormat(let input):
+            return "Invalid batch entry format: '\(input)'. Expected 'key=lang:value,lang:value'"
+        case .emptyKey(let input):
+            return "Empty key in: '\(input)'"
+        case .invalidTranslationFormat(let input):
+            return "Invalid translation format: '\(input)'. Expected 'lang:value'"
+        case .emptyLanguage(let input):
+            return "Empty language code in: '\(input)'"
+        case .noTranslations(let input):
+            return "No translations specified for: '\(input)'"
+        }
+    }
+}

--- a/Sources/XCStringsKit/Models/XCStrings.swift
+++ b/Sources/XCStringsKit/Models/XCStrings.swift
@@ -299,3 +299,55 @@ package struct CompactAggregatedCoverage: Codable, Sendable {
         self.completeCount = agg.averageCoverageByLanguage.count - incomplete.count
     }
 }
+
+// MARK: - Batch Operation Models
+
+/// Result of batch key existence check
+package struct BatchCheckKeysResult: Codable, Sendable {
+    package let results: [String: Bool]  // key -> exists
+    package let existingKeys: [String]
+    package let missingKeys: [String]
+
+    package init(results: [String: Bool]) {
+        self.results = results
+        self.existingKeys = results.filter { $0.value }.keys.sorted()
+        self.missingKeys = results.filter { !$0.value }.keys.sorted()
+    }
+}
+
+/// Single entry for batch add/update operations
+package struct BatchTranslationEntry: Codable, Sendable {
+    package let key: String
+    package let translations: [String: String]  // language -> value
+
+    package init(key: String, translations: [String: String]) {
+        self.key = key
+        self.translations = translations
+    }
+}
+
+/// Result of batch add/update operations
+package struct BatchWriteResult: Codable, Sendable {
+    package let successCount: Int
+    package let failedCount: Int
+    package let succeeded: [String]
+    package let failed: [BatchWriteError]
+
+    package init(succeeded: [String], failed: [BatchWriteError]) {
+        self.successCount = succeeded.count
+        self.failedCount = failed.count
+        self.succeeded = succeeded
+        self.failed = failed
+    }
+}
+
+/// Error info for batch write operations
+package struct BatchWriteError: Codable, Sendable {
+    package let key: String
+    package let error: String
+
+    package init(key: String, error: String) {
+        self.key = key
+        self.error = error
+    }
+}

--- a/Sources/XCStringsKit/XCStringsParser.swift
+++ b/Sources/XCStringsKit/XCStringsParser.swift
@@ -76,6 +76,12 @@ package actor XCStringsParser {
         return XCStringsReader(file: file).checkKey(key, language: language)
     }
 
+    /// Check if multiple keys exist
+    package func checkKeys(_ keys: [String], language: String?) throws -> BatchCheckKeysResult {
+        let file = try load()
+        return XCStringsReader(file: file).checkKeys(keys, language: language)
+    }
+
     /// Check coverage for a key
     package func checkCoverage(_ key: String) throws -> CoverageInfo {
         let file = try load()
@@ -152,6 +158,24 @@ package actor XCStringsParser {
         let file = try load()
         let updated = try XCStringsWriter.updateTranslations(in: file, key: key, translations: translations)
         try save(updated)
+    }
+
+    // MARK: - Batch Operations (Multiple Keys)
+
+    /// Add translations for multiple keys at once
+    package func addTranslationsBatch(entries: [BatchTranslationEntry], allowOverwrite: Bool = false) throws -> BatchWriteResult {
+        let file = try load()
+        let (updated, result) = XCStringsWriter.addTranslationsBatch(to: file, entries: entries, allowOverwrite: allowOverwrite)
+        try save(updated)
+        return result
+    }
+
+    /// Update translations for multiple keys at once
+    package func updateTranslationsBatch(entries: [BatchTranslationEntry]) throws -> BatchWriteResult {
+        let file = try load()
+        let (updated, result) = XCStringsWriter.updateTranslationsBatch(in: file, entries: entries)
+        try save(updated)
+        return result
     }
 
     /// Rename a key

--- a/Sources/XCStringsKit/XCStringsReader.swift
+++ b/Sources/XCStringsKit/XCStringsReader.swift
@@ -15,32 +15,21 @@ struct XCStringsReader: Sendable {
 
     /// Get all languages used in the file
     func listLanguages() -> [String] {
-        var languages = Set<String>()
-        languages.insert(file.sourceLanguage)
-
-        for entry in file.strings.values {
-            if let localizations = entry.localizations {
-                languages.formUnion(localizations.keys)
-            }
-        }
-
-        return languages.sorted()
+        file.strings.values.lazy
+            .compactMap(\.localizations?.keys)
+            .reduce(into: Set([file.sourceLanguage])) { $0.formUnion($1) }
+            .sorted()
     }
 
     /// Get untranslated keys for a specific language
     func listUntranslated(for language: String) -> [String] {
-        var untranslated: [String] = []
-
-        for (key, entry) in file.strings {
-            let isTranslated = entry.localizations?[language]?.stringUnit?.value != nil
-                || entry.localizations?[language]?.variations != nil
-
-            if !isTranslated {
-                untranslated.append(key)
+        file.strings
+            .filter { _, entry in
+                let localization = entry.localizations?[language]
+                return localization?.stringUnit?.value == nil && localization?.variations == nil
             }
-        }
-
-        return untranslated.sorted()
+            .keys
+            .sorted()
     }
 
     /// Get source language
@@ -84,18 +73,16 @@ struct XCStringsReader: Sendable {
             } else {
                 throw XCStringsError.languageNotFound(language: lang, key: key)
             }
-        } else {
-            if let localizations = entry.localizations {
-                for (lang, localization) in localizations {
-                    result[lang] = TranslationInfo(
-                        key: key,
-                        language: lang,
-                        value: localization.stringUnit?.value,
-                        state: localization.stringUnit?.state,
-                        hasVariations: localization.variations != nil
-                    )
-                }
-            }
+        } else if let localizations = entry.localizations {
+            result = Dictionary(uniqueKeysWithValues: localizations.map { lang, localization in
+                (lang, TranslationInfo(
+                    key: key,
+                    language: lang,
+                    value: localization.stringUnit?.value,
+                    state: localization.stringUnit?.state,
+                    hasVariations: localization.variations != nil
+                ))
+            })
         }
 
         return result
@@ -112,6 +99,12 @@ struct XCStringsReader: Sendable {
         }
 
         return true
+    }
+
+    /// Check if multiple keys exist
+    func checkKeys(_ keys: [String], language: String?) -> BatchCheckKeysResult {
+        let results = Dictionary(uniqueKeysWithValues: keys.lazy.map { ($0, checkKey($0, language: language)) })
+        return BatchCheckKeysResult(results: results)
     }
 
     /// Check coverage for a key

--- a/Sources/XCStringsKit/XCStringsWriter.swift
+++ b/Sources/XCStringsKit/XCStringsWriter.swift
@@ -191,4 +191,58 @@ enum XCStringsWriter {
 
         return result
     }
+
+    // MARK: - Batch Operations
+
+    /// Add translations for multiple keys at once
+    static func addTranslationsBatch(
+        to file: XCStringsFile,
+        entries: [BatchTranslationEntry],
+        allowOverwrite: Bool = false
+    ) -> (file: XCStringsFile, result: BatchWriteResult) {
+        var result = file
+        var succeeded: [String] = []
+        var failed: [BatchWriteError] = []
+
+        for entry in entries {
+            do {
+                result = try addTranslations(
+                    to: result,
+                    key: entry.key,
+                    translations: entry.translations,
+                    allowOverwrite: allowOverwrite
+                )
+                succeeded.append(entry.key)
+            } catch {
+                failed.append(BatchWriteError(key: entry.key, error: error.localizedDescription))
+            }
+        }
+
+        return (result, BatchWriteResult(succeeded: succeeded, failed: failed))
+    }
+
+    /// Update translations for multiple keys at once
+    static func updateTranslationsBatch(
+        in file: XCStringsFile,
+        entries: [BatchTranslationEntry]
+    ) -> (file: XCStringsFile, result: BatchWriteResult) {
+        var result = file
+        var succeeded: [String] = []
+        var failed: [BatchWriteError] = []
+
+        for entry in entries {
+            do {
+                result = try updateTranslations(
+                    in: result,
+                    key: entry.key,
+                    translations: entry.translations
+                )
+                succeeded.append(entry.key)
+            } catch {
+                failed.append(BatchWriteError(key: entry.key, error: error.localizedDescription))
+            }
+        }
+
+        return (result, BatchWriteResult(succeeded: succeeded, failed: failed))
+    }
 }

--- a/Sources/XCStringsMCP/MCPServer.swift
+++ b/Sources/XCStringsMCP/MCPServer.swift
@@ -153,6 +153,66 @@ public struct XCStringsMCPServer {
                     "required": .array([.string("files")]),
                 ])
             ),
+            Tool(
+                name: "xcstrings_batch_check_keys",
+                description: "Check if multiple keys exist in the xcstrings file. Returns results for each key.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "file": .object(["type": .string("string"), "description": .string("Path to the xcstrings file")]),
+                        "keys": .object(["type": .string("array"), "items": .object(["type": .string("string")]), "description": .string("Array of keys to check")]),
+                        "language": .object(["type": .string("string"), "description": .string("Optional specific language to check")]),
+                    ]),
+                    "required": .array([.string("file"), .string("keys")]),
+                ])
+            ),
+            Tool(
+                name: "xcstrings_batch_add_translations",
+                description: "Add translations for multiple keys at once. Each entry contains a key and its translations for multiple languages.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "file": .object(["type": .string("string"), "description": .string("Path to the xcstrings file")]),
+                        "entries": .object([
+                            "type": .string("array"),
+                            "items": .object([
+                                "type": .string("object"),
+                                "properties": .object([
+                                    "key": .object(["type": .string("string"), "description": .string("The key to add translations for")]),
+                                    "translations": .object(["type": .string("object"), "description": .string("Object mapping language codes to translation values")]),
+                                ]),
+                                "required": .array([.string("key"), .string("translations")]),
+                            ]),
+                            "description": .string("Array of entries, each with a key and translations object"),
+                        ]),
+                        "overwrite": .object(["type": .string("boolean"), "description": .string("Allow overwriting existing translations (default: false)")]),
+                    ]),
+                    "required": .array([.string("file"), .string("entries")]),
+                ])
+            ),
+            Tool(
+                name: "xcstrings_batch_update_translations",
+                description: "Update translations for multiple keys at once. Each entry contains a key and its translations for multiple languages.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "file": .object(["type": .string("string"), "description": .string("Path to the xcstrings file")]),
+                        "entries": .object([
+                            "type": .string("array"),
+                            "items": .object([
+                                "type": .string("object"),
+                                "properties": .object([
+                                    "key": .object(["type": .string("string"), "description": .string("The key to update translations for")]),
+                                    "translations": .object(["type": .string("object"), "description": .string("Object mapping language codes to translation values")]),
+                                ]),
+                                "required": .array([.string("key"), .string("translations")]),
+                            ]),
+                            "description": .string("Array of entries, each with a key and translations object"),
+                        ]),
+                    ]),
+                    "required": .array([.string("file"), .string("entries")]),
+                ])
+            ),
             // Create operations
             Tool(
                 name: "xcstrings_create_file",
@@ -466,6 +526,62 @@ public struct XCStringsMCPServer {
             let languages = languagesValue.compactMap { $0.stringValue }
             try await parser.deleteTranslations(key: key, languages: languages)
             return "Translations deleted successfully for \(languages.count) languages"
+
+        case "xcstrings_batch_check_keys":
+            guard let keysValue = args["keys"]?.arrayValue else {
+                throw XCStringsError.invalidJSON(reason: "Missing 'keys' parameter")
+            }
+            let keys = keysValue.compactMap { $0.stringValue }
+            let language = args["language"]?.stringValue
+            let result = try await parser.checkKeys(keys, language: language)
+            return try String(data: encoder.encode(result), encoding: .utf8) ?? "{}"
+
+        case "xcstrings_batch_add_translations":
+            guard let entriesValue = args["entries"]?.arrayValue else {
+                throw XCStringsError.invalidJSON(reason: "Missing 'entries' parameter")
+            }
+            let overwrite = args["overwrite"]?.boolValue ?? false
+            var entries: [BatchTranslationEntry] = []
+            for entryValue in entriesValue {
+                guard let entryObj = entryValue.objectValue,
+                      let key = entryObj["key"]?.stringValue,
+                      let translationsValue = entryObj["translations"]?.objectValue
+                else {
+                    throw XCStringsError.invalidJSON(reason: "Invalid entry format")
+                }
+                var translations: [String: String] = [:]
+                for (lang, value) in translationsValue {
+                    if let stringValue = value.stringValue {
+                        translations[lang] = stringValue
+                    }
+                }
+                entries.append(BatchTranslationEntry(key: key, translations: translations))
+            }
+            let result = try await parser.addTranslationsBatch(entries: entries, allowOverwrite: overwrite)
+            return try String(data: encoder.encode(result), encoding: .utf8) ?? "{}"
+
+        case "xcstrings_batch_update_translations":
+            guard let entriesValue = args["entries"]?.arrayValue else {
+                throw XCStringsError.invalidJSON(reason: "Missing 'entries' parameter")
+            }
+            var entries: [BatchTranslationEntry] = []
+            for entryValue in entriesValue {
+                guard let entryObj = entryValue.objectValue,
+                      let key = entryObj["key"]?.stringValue,
+                      let translationsValue = entryObj["translations"]?.objectValue
+                else {
+                    throw XCStringsError.invalidJSON(reason: "Invalid entry format")
+                }
+                var translations: [String: String] = [:]
+                for (lang, value) in translationsValue {
+                    if let stringValue = value.stringValue {
+                        translations[lang] = stringValue
+                    }
+                }
+                entries.append(BatchTranslationEntry(key: key, translations: translations))
+            }
+            let result = try await parser.updateTranslationsBatch(entries: entries)
+            return try String(data: encoder.encode(result), encoding: .utf8) ?? "{}"
 
         default:
             throw XCStringsError.invalidJSON(reason: "Unknown tool: \(params.name)")

--- a/Tests/XCStringsKitTests/AddOperationsTests.swift
+++ b/Tests/XCStringsKitTests/AddOperationsTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import XCStringsKit
 
-@Suite("Add Operations")
+@Suite("Adding new keys and translations to xcstrings files")
 struct AddOperationsTests {
     @Test("addTranslation adds new translation to existing key", arguments: [
         (FixtureType.singleKeySingleLang, "Hello", "ja", "こんにちは"),

--- a/Tests/XCStringsKitTests/BatchEntryParserTests.swift
+++ b/Tests/XCStringsKitTests/BatchEntryParserTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import XCStringsKit
+
+@Suite("Parsing batch entry format strings into BatchTranslationEntry")
+struct BatchEntryParserTests {
+    @Test("parse converts key=lang:value format correctly")
+    func parseSingleTranslation() throws {
+        let result = try BatchEntryParser.parse("Hello=en:Hello World")
+
+        #expect(result.key == "Hello")
+        #expect(result.translations == ["en": "Hello World"])
+    }
+
+    @Test("parse converts multiple lang:value pairs")
+    func parseMultipleTranslations() throws {
+        let result = try BatchEntryParser.parse("Hello=ja:こんにちは,en:Hello")
+
+        #expect(result.key == "Hello")
+        #expect(result.translations["ja"] == "こんにちは")
+        #expect(result.translations["en"] == "Hello")
+    }
+
+    @Test("parse handles value containing colons")
+    func parseValueWithColons() throws {
+        let result = try BatchEntryParser.parse("Time=en:12:30:45")
+
+        #expect(result.key == "Time")
+        #expect(result.translations["en"] == "12:30:45")
+    }
+
+    @Test("parse handles value containing equals sign")
+    func parseValueWithEquals() throws {
+        let result = try BatchEntryParser.parse("Math=en:1+1=2")
+
+        #expect(result.key == "Math")
+        #expect(result.translations["en"] == "1+1=2")
+    }
+
+    @Test("parse handles empty value")
+    func parseEmptyValue() throws {
+        let result = try BatchEntryParser.parse("Empty=en:")
+
+        #expect(result.key == "Empty")
+        #expect(result.translations["en"] == "")
+    }
+
+    @Test("parse throws invalidFormat for missing equals")
+    func parseMissingEquals() throws {
+        #expect(throws: BatchEntryParseError.self) {
+            try BatchEntryParser.parse("HelloWorld")
+        }
+    }
+
+    @Test("parse throws emptyKey for empty key")
+    func parseEmptyKey() throws {
+        #expect(throws: BatchEntryParseError.self) {
+            try BatchEntryParser.parse("=en:Hello")
+        }
+    }
+
+    @Test("parse throws invalidTranslationFormat for missing colon")
+    func parseMissingColon() throws {
+        #expect(throws: BatchEntryParseError.self) {
+            try BatchEntryParser.parse("Hello=enHello")
+        }
+    }
+
+    @Test("parse throws emptyLanguage for empty language code")
+    func parseEmptyLanguage() throws {
+        #expect(throws: BatchEntryParseError.self) {
+            try BatchEntryParser.parse("Hello=:Hello")
+        }
+    }
+
+    @Test("parse throws noTranslations for empty translations")
+    func parseNoTranslations() throws {
+        #expect(throws: BatchEntryParseError.self) {
+            try BatchEntryParser.parse("Hello=")
+        }
+    }
+}

--- a/Tests/XCStringsKitTests/BatchOperationsTests.swift
+++ b/Tests/XCStringsKitTests/BatchOperationsTests.swift
@@ -1,0 +1,226 @@
+import Foundation
+import Testing
+@testable import XCStringsKit
+
+@Suite("Batch operations for checking, adding, and updating multiple keys at once")
+struct BatchOperationsTests {
+    // MARK: - Check Keys Tests
+
+    @Test("checkKeys returns correct results for multiple keys")
+    func checkKeysMultiple() async throws {
+        let path = try TestHelper.createTempFile(content: FixtureType.multipleKeysPartialTranslations.content)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let result = try await parser.checkKeys(["Hello", "Goodbye", "Welcome", "NonExistent"], language: nil)
+
+        #expect(result.results["Hello"] == true)
+        #expect(result.results["Goodbye"] == true)
+        #expect(result.results["Welcome"] == true)
+        #expect(result.results["NonExistent"] == false)
+        #expect(result.existingKeys == ["Goodbye", "Hello", "Welcome"])
+        #expect(result.missingKeys == ["NonExistent"])
+    }
+
+    @Test("checkKeys with language filter", arguments: [
+        (FixtureType.multipleKeysPartialTranslations, "ja", ["Hello", "Welcome"], ["Goodbye"]),
+        (FixtureType.multipleKeysPartialTranslations, "de", ["Welcome"], ["Goodbye", "Hello"]),
+    ])
+    func checkKeysWithLanguage(fixture: FixtureType, language: String, expectedExisting: [String], expectedMissing: [String]) async throws {
+        let path = try TestHelper.createTempFile(content: fixture.content)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let result = try await parser.checkKeys(["Hello", "Goodbye", "Welcome"], language: language)
+
+        #expect(result.existingKeys == expectedExisting)
+        #expect(result.missingKeys == expectedMissing)
+    }
+
+    @Test("checkKeys with empty keys array")
+    func checkKeysEmpty() async throws {
+        let path = try TestHelper.createTempFile(content: FixtureType.singleKeySingleLang.content)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let result = try await parser.checkKeys([], language: nil)
+
+        #expect(result.results.isEmpty)
+        #expect(result.existingKeys.isEmpty)
+        #expect(result.missingKeys.isEmpty)
+    }
+
+    // MARK: - Batch Add Translations Tests
+
+    @Test("addTranslationsBatch adds multiple keys successfully")
+    func addTranslationsBatchMultipleKeys() async throws {
+        let path = try TestHelper.createTempFile(content: FixtureType.empty.content)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let entries = [
+            BatchTranslationEntry(key: "Hello", translations: ["en": "Hello", "ja": "こんにちは"]),
+            BatchTranslationEntry(key: "Goodbye", translations: ["en": "Goodbye", "ja": "さようなら"]),
+            BatchTranslationEntry(key: "Thanks", translations: ["en": "Thanks"]),
+        ]
+
+        let result = try await parser.addTranslationsBatch(entries: entries)
+
+        #expect(result.successCount == 3)
+        #expect(result.failedCount == 0)
+        #expect(result.succeeded.contains("Hello"))
+        #expect(result.succeeded.contains("Goodbye"))
+        #expect(result.succeeded.contains("Thanks"))
+
+        // Verify data was written
+        let keys = try await parser.listKeys()
+        #expect(keys.count == 3)
+        #expect(keys.contains("Hello"))
+        #expect(keys.contains("Goodbye"))
+        #expect(keys.contains("Thanks"))
+
+        let translation = try await parser.getTranslation(key: "Hello", language: "ja")
+        #expect(translation["ja"]?.value == "こんにちは")
+    }
+
+    @Test("addTranslationsBatch fails for duplicate keys without overwrite")
+    func addTranslationsBatchDuplicateKey() async throws {
+        let path = try TestHelper.createTempFile(content: FixtureType.singleKeySingleLang.content)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let entries = [
+            BatchTranslationEntry(key: "Hello", translations: ["en": "New Hello"]),  // Already exists
+            BatchTranslationEntry(key: "NewKey", translations: ["en": "New Value"]),
+        ]
+
+        let result = try await parser.addTranslationsBatch(entries: entries, allowOverwrite: false)
+
+        #expect(result.successCount == 1)
+        #expect(result.failedCount == 1)
+        #expect(result.succeeded.contains("NewKey"))
+        #expect(result.failed.count == 1)
+        #expect(result.failed[0].key == "Hello")
+    }
+
+    @Test("addTranslationsBatch allows overwrite when flag is set")
+    func addTranslationsBatchWithOverwrite() async throws {
+        let path = try TestHelper.createTempFile(content: FixtureType.singleKeySingleLang.content)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let entries = [
+            BatchTranslationEntry(key: "Hello", translations: ["en": "Updated Hello"]),
+        ]
+
+        let result = try await parser.addTranslationsBatch(entries: entries, allowOverwrite: true)
+
+        #expect(result.successCount == 1)
+        #expect(result.failedCount == 0)
+
+        let translation = try await parser.getTranslation(key: "Hello", language: "en")
+        #expect(translation["en"]?.value == "Updated Hello")
+    }
+
+    // MARK: - Batch Update Translations Tests
+
+    @Test("updateTranslationsBatch updates multiple keys successfully")
+    func updateTranslationsBatchMultipleKeys() async throws {
+        let path = try TestHelper.createTempFile(content: FixtureType.multipleKeysPartialTranslations.content)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let entries = [
+            BatchTranslationEntry(key: "Hello", translations: ["en": "Hi there"]),
+            BatchTranslationEntry(key: "Welcome", translations: ["en": "Welcome!", "ja": "ようこそ！"]),
+        ]
+
+        let result = try await parser.updateTranslationsBatch(entries: entries)
+
+        #expect(result.successCount == 2)
+        #expect(result.failedCount == 0)
+
+        let helloTranslation = try await parser.getTranslation(key: "Hello", language: "en")
+        #expect(helloTranslation["en"]?.value == "Hi there")
+
+        let welcomeTranslation = try await parser.getTranslation(key: "Welcome", language: "en")
+        #expect(welcomeTranslation["en"]?.value == "Welcome!")
+    }
+
+    @Test("updateTranslationsBatch fails for non-existent keys")
+    func updateTranslationsBatchNonExistent() async throws {
+        let path = try TestHelper.createTempFile(content: FixtureType.singleKeySingleLang.content)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let entries = [
+            BatchTranslationEntry(key: "Hello", translations: ["en": "Updated"]),
+            BatchTranslationEntry(key: "NonExistent", translations: ["en": "Value"]),
+        ]
+
+        let result = try await parser.updateTranslationsBatch(entries: entries)
+
+        #expect(result.successCount == 1)
+        #expect(result.failedCount == 1)
+        #expect(result.succeeded.contains("Hello"))
+        #expect(result.failed[0].key == "NonExistent")
+    }
+
+    @Test("updateTranslationsBatch fails for non-existent language")
+    func updateTranslationsBatchNonExistentLanguage() async throws {
+        let path = try TestHelper.createTempFile(content: FixtureType.singleKeySingleLang.content)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let entries = [
+            BatchTranslationEntry(key: "Hello", translations: ["fr": "Bonjour"]),  // Language doesn't exist
+        ]
+
+        let result = try await parser.updateTranslationsBatch(entries: entries)
+
+        #expect(result.successCount == 0)
+        #expect(result.failedCount == 1)
+    }
+
+    // MARK: - Edge Cases
+
+    @Test("batch operations with empty entries array")
+    func batchOperationsEmptyEntries() async throws {
+        let path = try TestHelper.createTempFile(content: FixtureType.empty.content)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+
+        let addResult = try await parser.addTranslationsBatch(entries: [])
+        #expect(addResult.successCount == 0)
+        #expect(addResult.failedCount == 0)
+
+        let updateResult = try await parser.updateTranslationsBatch(entries: [])
+        #expect(updateResult.successCount == 0)
+        #expect(updateResult.failedCount == 0)
+    }
+
+    @Test("batch add preserves file integrity on partial failure")
+    func batchAddPartialFailureIntegrity() async throws {
+        let path = try TestHelper.createTempFile(content: FixtureType.singleKeySingleLang.content)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let entries = [
+            BatchTranslationEntry(key: "NewKey1", translations: ["en": "Value1"]),
+            BatchTranslationEntry(key: "Hello", translations: ["en": "Duplicate"]),  // Will fail
+            BatchTranslationEntry(key: "NewKey2", translations: ["en": "Value2"]),
+        ]
+
+        let result = try await parser.addTranslationsBatch(entries: entries, allowOverwrite: false)
+
+        #expect(result.successCount == 2)
+        #expect(result.failedCount == 1)
+
+        // Verify successful entries were added
+        let keys = try await parser.listKeys()
+        #expect(keys.contains("NewKey1"))
+        #expect(keys.contains("NewKey2"))
+        #expect(keys.contains("Hello"))  // Original still exists
+    }
+}

--- a/Tests/XCStringsKitTests/BatchOperationsTests.swift
+++ b/Tests/XCStringsKitTests/BatchOperationsTests.swift
@@ -6,55 +6,30 @@ import Testing
 struct BatchOperationsTests {
     // MARK: - Check Keys Tests
 
-    @Test("checkKeys returns correct results for multiple keys")
-    func checkKeysMultiple() async throws {
-        let path = try TestHelper.createTempFile(content: FixtureType.multipleKeysPartialTranslations.content)
-        defer { TestHelper.removeTempFile(at: path) }
-
-        let parser = XCStringsParser(path: path)
-        let result = try await parser.checkKeys(["Hello", "Goodbye", "Welcome", "NonExistent"], language: nil)
-
-        #expect(result.results["Hello"] == true)
-        #expect(result.results["Goodbye"] == true)
-        #expect(result.results["Welcome"] == true)
-        #expect(result.results["NonExistent"] == false)
-        #expect(result.existingKeys == ["Goodbye", "Hello", "Welcome"])
-        #expect(result.missingKeys == ["NonExistent"])
-    }
-
-    @Test("checkKeys with language filter", arguments: [
-        (FixtureType.multipleKeysPartialTranslations, "ja", ["Hello", "Welcome"], ["Goodbye"]),
-        (FixtureType.multipleKeysPartialTranslations, "de", ["Welcome"], ["Goodbye", "Hello"]),
+    @Test("checkKeys returns correct results for multiple keys", arguments: [
+        (FixtureType.multipleKeysPartialTranslations, ["Hello", "Goodbye", "Welcome", "NonExistent"], nil as String?, ["Goodbye", "Hello", "Welcome"], ["NonExistent"]),
+        (FixtureType.multipleKeysPartialTranslations, ["Hello", "Goodbye", "Welcome"], "ja", ["Hello", "Welcome"], ["Goodbye"]),
+        (FixtureType.multipleKeysPartialTranslations, ["Hello", "Goodbye", "Welcome"], "de", ["Welcome"], ["Goodbye", "Hello"]),
+        (FixtureType.singleKeySingleLang, [], nil as String?, [] as [String], [] as [String]),
     ])
-    func checkKeysWithLanguage(fixture: FixtureType, language: String, expectedExisting: [String], expectedMissing: [String]) async throws {
+    func checkKeysMultiple(fixture: FixtureType, keys: [String], language: String?, expectedExisting: [String], expectedMissing: [String]) async throws {
         let path = try TestHelper.createTempFile(content: fixture.content)
         defer { TestHelper.removeTempFile(at: path) }
 
         let parser = XCStringsParser(path: path)
-        let result = try await parser.checkKeys(["Hello", "Goodbye", "Welcome"], language: language)
+        let result = try await parser.checkKeys(keys, language: language)
 
         #expect(result.existingKeys == expectedExisting)
         #expect(result.missingKeys == expectedMissing)
     }
 
-    @Test("checkKeys with empty keys array")
-    func checkKeysEmpty() async throws {
-        let path = try TestHelper.createTempFile(content: FixtureType.singleKeySingleLang.content)
-        defer { TestHelper.removeTempFile(at: path) }
-
-        let parser = XCStringsParser(path: path)
-        let result = try await parser.checkKeys([], language: nil)
-
-        #expect(result.results.isEmpty)
-        #expect(result.existingKeys.isEmpty)
-        #expect(result.missingKeys.isEmpty)
-    }
-
     // MARK: - Batch Add Translations Tests
 
-    @Test("addTranslationsBatch adds multiple keys successfully")
-    func addTranslationsBatchMultipleKeys() async throws {
-        let path = try TestHelper.createTempFile(content: FixtureType.empty.content)
+    @Test("addTranslationsBatch adds multiple keys successfully", arguments: [
+        FixtureType.empty,
+    ])
+    func addTranslationsBatchMultipleKeys(fixture: FixtureType) async throws {
+        let path = try TestHelper.createTempFile(content: fixture.content)
         defer { TestHelper.removeTempFile(at: path) }
 
         let parser = XCStringsParser(path: path)
@@ -68,58 +43,37 @@ struct BatchOperationsTests {
 
         #expect(result.successCount == 3)
         #expect(result.failedCount == 0)
-        #expect(result.succeeded.contains("Hello"))
-        #expect(result.succeeded.contains("Goodbye"))
-        #expect(result.succeeded.contains("Thanks"))
+        #expect(Set(result.succeeded) == Set(["Hello", "Goodbye", "Thanks"]))
 
         // Verify data was written
         let keys = try await parser.listKeys()
         #expect(keys.count == 3)
-        #expect(keys.contains("Hello"))
-        #expect(keys.contains("Goodbye"))
-        #expect(keys.contains("Thanks"))
+        #expect(Set(keys) == Set(["Hello", "Goodbye", "Thanks"]))
 
         let translation = try await parser.getTranslation(key: "Hello", language: "ja")
         #expect(translation["ja"]?.value == "こんにちは")
     }
 
-    @Test("addTranslationsBatch fails for duplicate keys without overwrite")
-    func addTranslationsBatchDuplicateKey() async throws {
-        let path = try TestHelper.createTempFile(content: FixtureType.singleKeySingleLang.content)
-        defer { TestHelper.removeTempFile(at: path) }
-
-        let parser = XCStringsParser(path: path)
-        let entries = [
-            BatchTranslationEntry(key: "Hello", translations: ["en": "New Hello"]),  // Already exists
-            BatchTranslationEntry(key: "NewKey", translations: ["en": "New Value"]),
-        ]
-
-        let result = try await parser.addTranslationsBatch(entries: entries, allowOverwrite: false)
-
-        #expect(result.successCount == 1)
-        #expect(result.failedCount == 1)
-        #expect(result.succeeded.contains("NewKey"))
-        #expect(result.failed.count == 1)
-        #expect(result.failed[0].key == "Hello")
-    }
-
-    @Test("addTranslationsBatch allows overwrite when flag is set")
-    func addTranslationsBatchWithOverwrite() async throws {
-        let path = try TestHelper.createTempFile(content: FixtureType.singleKeySingleLang.content)
+    @Test("addTranslationsBatch handles duplicate and overwrite scenarios", arguments: [
+        (FixtureType.singleKeySingleLang, false, 1, 1, ["NewKey"], ["Hello"]),
+        (FixtureType.singleKeySingleLang, true, 2, 0, ["Hello", "NewKey"], [] as [String]),
+    ])
+    func addTranslationsBatchDuplicateHandling(fixture: FixtureType, allowOverwrite: Bool, expectedSuccess: Int, expectedFailed: Int, expectedSucceeded: [String], expectedFailedKeys: [String]) async throws {
+        let path = try TestHelper.createTempFile(content: fixture.content)
         defer { TestHelper.removeTempFile(at: path) }
 
         let parser = XCStringsParser(path: path)
         let entries = [
             BatchTranslationEntry(key: "Hello", translations: ["en": "Updated Hello"]),
+            BatchTranslationEntry(key: "NewKey", translations: ["en": "New Value"]),
         ]
 
-        let result = try await parser.addTranslationsBatch(entries: entries, allowOverwrite: true)
+        let result = try await parser.addTranslationsBatch(entries: entries, allowOverwrite: allowOverwrite)
 
-        #expect(result.successCount == 1)
-        #expect(result.failedCount == 0)
-
-        let translation = try await parser.getTranslation(key: "Hello", language: "en")
-        #expect(translation["en"]?.value == "Updated Hello")
+        #expect(result.successCount == expectedSuccess)
+        #expect(result.failedCount == expectedFailed)
+        #expect(Set(result.succeeded) == Set(expectedSucceeded))
+        #expect(Set(result.failed.map(\.key)) == Set(expectedFailedKeys))
     }
 
     // MARK: - Batch Update Translations Tests
@@ -147,8 +101,28 @@ struct BatchOperationsTests {
         #expect(welcomeTranslation["en"]?.value == "Welcome!")
     }
 
-    @Test("updateTranslationsBatch fails for non-existent keys")
-    func updateTranslationsBatchNonExistent() async throws {
+    @Test("updateTranslationsBatch fails for invalid scenarios", arguments: [
+        (FixtureType.singleKeySingleLang, "NonExistent", ["en": "Value"], "NonExistent"),
+        (FixtureType.singleKeySingleLang, "Hello", ["fr": "Bonjour"], "Hello"),
+    ])
+    func updateTranslationsBatchFailures(fixture: FixtureType, key: String, translations: [String: String], expectedFailedKey: String) async throws {
+        let path = try TestHelper.createTempFile(content: fixture.content)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let entries = [
+            BatchTranslationEntry(key: key, translations: translations),
+        ]
+
+        let result = try await parser.updateTranslationsBatch(entries: entries)
+
+        #expect(result.successCount == 0)
+        #expect(result.failedCount == 1)
+        #expect(result.failed[0].key == expectedFailedKey)
+    }
+
+    @Test("updateTranslationsBatch with mixed success and failure")
+    func updateTranslationsBatchMixed() async throws {
         let path = try TestHelper.createTempFile(content: FixtureType.singleKeySingleLang.content)
         defer { TestHelper.removeTempFile(at: path) }
 
@@ -166,27 +140,14 @@ struct BatchOperationsTests {
         #expect(result.failed[0].key == "NonExistent")
     }
 
-    @Test("updateTranslationsBatch fails for non-existent language")
-    func updateTranslationsBatchNonExistentLanguage() async throws {
-        let path = try TestHelper.createTempFile(content: FixtureType.singleKeySingleLang.content)
-        defer { TestHelper.removeTempFile(at: path) }
-
-        let parser = XCStringsParser(path: path)
-        let entries = [
-            BatchTranslationEntry(key: "Hello", translations: ["fr": "Bonjour"]),  // Language doesn't exist
-        ]
-
-        let result = try await parser.updateTranslationsBatch(entries: entries)
-
-        #expect(result.successCount == 0)
-        #expect(result.failedCount == 1)
-    }
-
     // MARK: - Edge Cases
 
-    @Test("batch operations with empty entries array")
-    func batchOperationsEmptyEntries() async throws {
-        let path = try TestHelper.createTempFile(content: FixtureType.empty.content)
+    @Test("batch operations with empty entries array", arguments: [
+        FixtureType.empty,
+        FixtureType.singleKeySingleLang,
+    ])
+    func batchOperationsEmptyEntries(fixture: FixtureType) async throws {
+        let path = try TestHelper.createTempFile(content: fixture.content)
         defer { TestHelper.removeTempFile(at: path) }
 
         let parser = XCStringsParser(path: path)
@@ -208,7 +169,7 @@ struct BatchOperationsTests {
         let parser = XCStringsParser(path: path)
         let entries = [
             BatchTranslationEntry(key: "NewKey1", translations: ["en": "Value1"]),
-            BatchTranslationEntry(key: "Hello", translations: ["en": "Duplicate"]),  // Will fail
+            BatchTranslationEntry(key: "Hello", translations: ["en": "Duplicate"]),
             BatchTranslationEntry(key: "NewKey2", translations: ["en": "Value2"]),
         ]
 
@@ -221,6 +182,6 @@ struct BatchOperationsTests {
         let keys = try await parser.listKeys()
         #expect(keys.contains("NewKey1"))
         #expect(keys.contains("NewKey2"))
-        #expect(keys.contains("Hello"))  // Original still exists
+        #expect(keys.contains("Hello"))
     }
 }

--- a/Tests/XCStringsKitTests/CheckOperationsTests.swift
+++ b/Tests/XCStringsKitTests/CheckOperationsTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import XCStringsKit
 
-@Suite("Check Operations")
+@Suite("Checking key existence and translation coverage")
 struct CheckOperationsTests {
     @Test("checkKey returns true for existing key", arguments: [
         (FixtureType.singleKeySingleLang, "Hello"),

--- a/Tests/XCStringsKitTests/ConcurrentAccessTests.swift
+++ b/Tests/XCStringsKitTests/ConcurrentAccessTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import XCStringsKit
 
-@Suite("Concurrent Access")
+@Suite("Thread safety for concurrent read operations")
 struct ConcurrentAccessTests {
     @Test("Concurrent reads are safe")
     func concurrentReads() async throws {

--- a/Tests/XCStringsKitTests/DeleteOperationsTests.swift
+++ b/Tests/XCStringsKitTests/DeleteOperationsTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import XCStringsKit
 
-@Suite("Delete Operations")
+@Suite("Deleting keys and translations from xcstrings files")
 struct DeleteOperationsTests {
     @Test("deleteKey removes key entirely", arguments: [
         (FixtureType.singleKeySingleLang, "Hello"),

--- a/Tests/XCStringsKitTests/ErrorHandlingTests.swift
+++ b/Tests/XCStringsKitTests/ErrorHandlingTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import XCStringsKit
 
-@Suite("Error Handling")
+@Suite("Error handling for invalid files, malformed JSON, and edge cases")
 struct ErrorHandlingTests {
     @Test("Parser throws for non-existent file")
     func fileNotFound() async throws {

--- a/Tests/XCStringsKitTests/GetOperationsTests.swift
+++ b/Tests/XCStringsKitTests/GetOperationsTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import XCStringsKit
 
-@Suite("Get Operations")
+@Suite("Retrieving translations, key info, and source language from xcstrings files")
 struct GetOperationsTests {
     @Test("getSourceLanguage returns correct language", arguments: FixtureType.allCases)
     func getSourceLanguage(fixture: FixtureType) async throws {

--- a/Tests/XCStringsKitTests/ListOperationsTests.swift
+++ b/Tests/XCStringsKitTests/ListOperationsTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import XCStringsKit
 
-@Suite("List Operations")
+@Suite("Listing keys, languages, and untranslated entries from xcstrings files")
 struct ListOperationsTests {
     @Test("listKeys returns correct count", arguments: FixtureType.allCases)
     func listKeysCount(fixture: FixtureType) async throws {

--- a/Tests/XCStringsKitTests/PersistenceTests.swift
+++ b/Tests/XCStringsKitTests/PersistenceTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import XCStringsKit
 
-@Suite("Persistence")
+@Suite("Verifying changes are correctly saved to disk after operations")
 struct PersistenceTests {
     @Test("Changes are persisted to file", arguments: [
         FixtureType.empty,

--- a/Tests/XCStringsKitTests/RenameOperationsTests.swift
+++ b/Tests/XCStringsKitTests/RenameOperationsTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import XCStringsKit
 
-@Suite("Rename Operations")
+@Suite("Renaming keys while preserving all translations")
 struct RenameOperationsTests {
     @Test("renameKey renames key preserving translations", arguments: [
         (FixtureType.singleKeySingleLang, "Hello", "Greeting"),

--- a/Tests/XCStringsKitTests/StatsOperationsTests.swift
+++ b/Tests/XCStringsKitTests/StatsOperationsTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import XCStringsKit
 
-@Suite("Stats Operations")
+@Suite("Calculating translation coverage and progress statistics")
 struct StatsOperationsTests {
     @Test("getStats returns correct total keys", arguments: FixtureType.allCases)
     func getStatsTotalKeys(fixture: FixtureType) async throws {

--- a/Tests/XCStringsKitTests/TranslationParserTests.swift
+++ b/Tests/XCStringsKitTests/TranslationParserTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import XCStringsKit
 
-@Suite("TranslationParser")
+@Suite("Parsing lang:value format strings into translation dictionaries")
 struct TranslationParserTests {
     // MARK: - parse
 

--- a/Tests/XCStringsKitTests/UpdateOperationsTests.swift
+++ b/Tests/XCStringsKitTests/UpdateOperationsTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import XCStringsKit
 
-@Suite("Update Operations")
+@Suite("Updating existing translations in xcstrings files")
 struct UpdateOperationsTests {
     @Test("updateTranslation updates existing translation", arguments: [
         (FixtureType.singleKeySingleLang, "Hello", "en", "Hi there"),


### PR DESCRIPTION
## Summary
- Add batch operations to check, add, and update multiple keys at once
- CLI: `xcstrings-crud batch check/add/update` subcommands
- MCP: `xcstrings_batch_check_keys`, `xcstrings_batch_add_translations`, `xcstrings_batch_update_translations` tools
- Refactor code to use higher-order functions with lazy evaluation for better performance
- Improve test suite descriptions to be more meaningful

## New Features

### CLI Usage
```bash
# Check multiple keys exist
xcstrings-crud batch check -k Hello -k Goodbye -f file.xcstrings

# Add multiple keys with translations
xcstrings-crud batch add -f file.xcstrings \
  -e "Hello=ja:こんにちは,en:Hello" \
  -e "Goodbye=ja:さようなら,en:Goodbye"

# Update multiple keys
xcstrings-crud batch update -f file.xcstrings \
  -e "Hello=ja:やあ" \
  -e "Goodbye=en:Bye"
```

### MCP Tools
- `xcstrings_batch_check_keys`: Check if multiple keys exist
- `xcstrings_batch_add_translations`: Add translations for multiple keys at once
- `xcstrings_batch_update_translations`: Update translations for multiple keys at once

## Test plan
- [x] All 108 tests pass
- [x] Batch check operations work correctly
- [x] Batch add operations work with partial failure handling
- [x] Batch update operations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)