### PR TITLE
Add batch list stale functionality for multiple xcstrings files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,58 @@ swift build -c release
 
 Binary will be at `.build/release/xcstrings-crud`.
 
+## MCP Server
+
+The MCP server is available as a subcommand:
+
+```bash
+xcstrings-crud mcp
+```
+
+### Configuration
+
+Add to your Claude Code MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "xcstrings-crud": {
+      "command": "xcstrings-crud",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `xcstrings_create_file` | Create a new xcstrings file |
+| `xcstrings_list_keys` | List all keys |
+| `xcstrings_list_languages` | List supported languages |
+| `xcstrings_list_untranslated` | List untranslated keys |
+| `xcstrings_list_stale` | List keys with stale extraction state |
+| `xcstrings_batch_list_stale` | List stale keys across multiple files |
+| `xcstrings_get_source_language` | Get source language |
+| `xcstrings_get_key` | Get translations for a key |
+| `xcstrings_check_key` | Check if key exists |
+| `xcstrings_check_coverage` | Check key language coverage |
+| `xcstrings_stats_coverage` | Get overall coverage statistics |
+| `xcstrings_stats_progress` | Get translation progress by language |
+| `xcstrings_batch_stats_coverage` | Get coverage for multiple files at once |
+| `xcstrings_batch_check_keys` | Check if multiple keys exist |
+| `xcstrings_batch_add_translations` | Add translations for multiple keys at once |
+| `xcstrings_batch_update_translations` | Update translations for multiple keys at once |
+| `xcstrings_add_translation` | Add translation for single language |
+| `xcstrings_add_translations` | Add translations for multiple languages |
+| `xcstrings_update_translation` | Update translation for single language |
+| `xcstrings_update_translations` | Update translations for multiple languages |
+| `xcstrings_rename_key` | Rename key |
+| `xcstrings_delete_key` | Delete entire key |
+| `xcstrings_delete_translation` | Delete translation for single language |
+| `xcstrings_delete_translations` | Delete translations for multiple languages |
+
 ## CLI Usage
 
 ### Create Operations
@@ -66,6 +118,9 @@ xcstrings-crud list untranslated --file path/to/Localizable.xcstrings --lang ja
 
 # List stale keys (potentially unused)
 xcstrings-crud list stale --file path/to/Localizable.xcstrings
+
+# List stale keys across multiple files
+xcstrings-crud batch stale -f file1.xcstrings file2.xcstrings file3.xcstrings
 
 # Get source language
 xcstrings-crud get source-language --file path/to/Localizable.xcstrings
@@ -125,6 +180,9 @@ xcstrings-crud delete key "Hello" --file path/to/Localizable.xcstrings -l ja en 
 ### Batch Operations
 
 ```bash
+# List stale keys across multiple files
+xcstrings-crud batch stale -f file1.xcstrings file2.xcstrings file3.xcstrings
+
 # Check if multiple keys exist
 xcstrings-crud batch check --file path/to/Localizable.xcstrings -k Hello Goodbye Welcome
 
@@ -150,57 +208,6 @@ xcstrings-crud batch update --file path/to/Localizable.xcstrings \
 
 - `--file <path>`: xcstrings file path (required)
 - `--pretty`: Pretty-printed JSON output
-
-## MCP Server
-
-The MCP server is available as a subcommand:
-
-```bash
-xcstrings-crud mcp
-```
-
-### Configuration
-
-Add to your Claude Code MCP settings:
-
-```json
-{
-  "mcpServers": {
-    "xcstrings-crud": {
-      "command": "xcstrings-crud",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-### Available Tools
-
-| Tool | Description |
-|------|-------------|
-| `xcstrings_create_file` | Create a new xcstrings file |
-| `xcstrings_list_keys` | List all keys |
-| `xcstrings_list_languages` | List supported languages |
-| `xcstrings_list_untranslated` | List untranslated keys |
-| `xcstrings_list_stale` | List keys with stale extraction state |
-| `xcstrings_get_source_language` | Get source language |
-| `xcstrings_get_key` | Get translations for a key |
-| `xcstrings_check_key` | Check if key exists |
-| `xcstrings_check_coverage` | Check key language coverage |
-| `xcstrings_stats_coverage` | Get overall coverage statistics |
-| `xcstrings_stats_progress` | Get translation progress by language |
-| `xcstrings_batch_stats_coverage` | Get coverage for multiple files at once |
-| `xcstrings_batch_check_keys` | Check if multiple keys exist |
-| `xcstrings_batch_add_translations` | Add translations for multiple keys at once |
-| `xcstrings_batch_update_translations` | Update translations for multiple keys at once |
-| `xcstrings_add_translation` | Add translation for single language |
-| `xcstrings_add_translations` | Add translations for multiple languages |
-| `xcstrings_update_translation` | Update translation for single language |
-| `xcstrings_update_translations` | Update translations for multiple languages |
-| `xcstrings_rename_key` | Rename key |
-| `xcstrings_delete_key` | Delete entire key |
-| `xcstrings_delete_translation` | Delete translation for single language |
-| `xcstrings_delete_translations` | Delete translations for multiple languages |
 
 ## Requirements
 

--- a/Sources/XCStringsKit/Models/XCStrings.swift
+++ b/Sources/XCStringsKit/Models/XCStrings.swift
@@ -351,3 +351,49 @@ package struct BatchWriteError: Codable, Sendable {
         self.error = error
     }
 }
+
+// MARK: - Stale Keys Models
+
+/// Constants for stale keys messages
+package enum StaleKeysConstants {
+    package static let note = "These keys are marked as 'stale' by Xcode, indicating they may no longer be used in source code. Please verify by searching for these keys in the module or project source code before deleting them."
+}
+
+/// Stale keys for a single file
+package struct FileStaleKeysSummary: Codable, Sendable {
+    package let file: String
+    package let staleKeys: [String]
+    package let count: Int
+
+    package init(file: String, staleKeys: [String]) {
+        self.file = file
+        self.staleKeys = staleKeys
+        self.count = staleKeys.count
+    }
+}
+
+/// Stale keys result for a single file
+package struct StaleKeysResult: Codable, Sendable {
+    package let staleKeys: [String]
+    package let count: Int
+    package let note: String
+
+    package init(staleKeys: [String]) {
+        self.staleKeys = staleKeys
+        self.count = staleKeys.count
+        self.note = StaleKeysConstants.note
+    }
+}
+
+/// Batch stale keys summary for multiple files
+package struct BatchStaleKeysSummary: Codable, Sendable {
+    package let files: [FileStaleKeysSummary]
+    package let totalStaleKeys: Int
+    package let note: String
+
+    package init(files: [FileStaleKeysSummary]) {
+        self.files = files
+        self.totalStaleKeys = files.reduce(0) { $0 + $1.count }
+        self.note = StaleKeysConstants.note
+    }
+}

--- a/Sources/XCStringsKit/XCStringsParser.swift
+++ b/Sources/XCStringsKit/XCStringsParser.swift
@@ -136,6 +136,17 @@ package actor XCStringsParser {
         return XCStringsStatsCalculator.getCompactBatchCoverage(files: files)
     }
 
+    /// Get batch stale keys for multiple files
+    package static func getBatchStaleKeys(paths: [String]) throws -> BatchStaleKeysSummary {
+        let fileSummaries: [FileStaleKeysSummary] = try paths.map { path in
+            let handler = XCStringsFileHandler(path: path)
+            let file = try handler.load()
+            let staleKeys = XCStringsReader(file: file).listStaleKeys()
+            return FileStaleKeysSummary(file: path, staleKeys: staleKeys)
+        }
+        return BatchStaleKeysSummary(files: fileSummaries)
+    }
+
     // MARK: - Write Operations
 
     /// Add a translation

--- a/Sources/XCStringsMCP/Handlers/ListToolHandlers.swift
+++ b/Sources/XCStringsMCP/Handlers/ListToolHandlers.swift
@@ -51,13 +51,19 @@ struct ListStaleHandler: ToolHandler {
         let file = try context.arguments.requireString("file")
         let parser = XCStringsParser(path: file)
         let staleKeys = try await parser.listStaleKeys()
+        let result = StaleKeysResult(staleKeys: staleKeys)
+        return try JSONEncoderHelper.encode(result)
+    }
+}
 
-        let response: [String: Any] = [
-            "staleKeys": staleKeys,
-            "count": staleKeys.count,
-            "note": "These keys are marked as 'stale' by Xcode, indicating they may no longer be used in source code. Please verify by searching for these keys in the module or project source code before deleting them.",
-        ]
-        let jsonData = try JSONSerialization.data(withJSONObject: response, options: [.prettyPrinted, .sortedKeys])
-        return String(data: jsonData, encoding: .utf8) ?? "{}"
+// MARK: - Batch List Stale Handler
+
+struct BatchListStaleHandler: ToolHandler {
+    static let toolName = "xcstrings_batch_list_stale"
+
+    func execute(with context: ToolContext) async throws -> String {
+        let files = try context.arguments.requireStringArray("files")
+        let result = try XCStringsParser.getBatchStaleKeys(paths: files)
+        return try JSONEncoderHelper.encode(result)
     }
 }

--- a/Sources/XCStringsMCP/MCPServer.swift
+++ b/Sources/XCStringsMCP/MCPServer.swift
@@ -70,13 +70,28 @@ public struct XCStringsMCPServer {
             ),
             Tool(
                 name: "xcstrings_list_stale",
-                description: "List keys with stale extraction state (potentially unused keys). Note: This only detects keys marked as 'stale' by Xcode. To verify if these keys are truly unused, you should search for their usage in the module or project's source code.",
+                description: "List keys with stale extraction state (potentially unused keys) in a single file. Note: This only detects keys marked as 'stale' by Xcode. To verify if these keys are truly unused, you should search for their usage in the module or project's source code.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
                         "file": .object(["type": .string("string"), "description": .string("Path to the xcstrings file")]),
                     ]),
                     "required": .array([.string("file")]),
+                ])
+            ),
+            Tool(
+                name: "xcstrings_batch_list_stale",
+                description: "List keys with stale extraction state across multiple xcstrings files at once. Returns stale keys per file and total count.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "files": .object([
+                            "type": .string("array"),
+                            "items": .object(["type": .string("string")]),
+                            "description": .string("Array of paths to xcstrings files"),
+                        ]),
+                    ]),
+                    "required": .array([.string("files")]),
                 ])
             ),
             Tool(

--- a/Sources/XCStringsMCP/ToolHandlerRegistry.swift
+++ b/Sources/XCStringsMCP/ToolHandlerRegistry.swift
@@ -17,6 +17,7 @@ actor ToolHandlerRegistry {
         ListLanguagesHandler.toolName: ListLanguagesHandler(),
         ListUntranslatedHandler.toolName: ListUntranslatedHandler(),
         ListStaleHandler.toolName: ListStaleHandler(),
+        BatchListStaleHandler.toolName: BatchListStaleHandler(),
 
         // Get handlers
         GetSourceLanguageHandler.toolName: GetSourceLanguageHandler(),

--- a/Tests/XCStringsMCPTests/ToolHandlerIntegrationTests.swift
+++ b/Tests/XCStringsMCPTests/ToolHandlerIntegrationTests.swift
@@ -73,6 +73,27 @@ struct ToolHandlerIntegrationTests {
         #expect(!result.contains("\"ActiveKey\""))
     }
 
+    @Test("BatchListStaleHandler returns stale keys across multiple files")
+    func batchListStaleHandler() async throws {
+        let path1 = try TestHelper.createTempFile(content: TestFixtures.withStaleKeys)
+        let path2 = try TestHelper.createTempFile(content: TestFixtures.singleKeySingleLang)
+        defer {
+            TestHelper.removeTempFile(at: path1)
+            TestHelper.removeTempFile(at: path2)
+        }
+
+        let handler = BatchListStaleHandler()
+        let context = ToolContext(arguments: ToolArguments(raw: [
+            "files": .array([.string(path1), .string(path2)])
+        ]))
+
+        let result = try await handler.execute(with: context)
+        #expect(result.contains("StaleKey1"))
+        #expect(result.contains("StaleKey2"))
+        #expect(result.contains("totalStaleKeys"))
+        #expect(result.contains("note"))
+    }
+
     // MARK: - Get Handlers
 
     @Test("GetSourceLanguageHandler returns source language")


### PR DESCRIPTION
## Summary
- Add `xcstrings_batch_list_stale` MCP tool and `batch stale` CLI command to list stale keys across multiple xcstrings files at once
- Apply SSoT principle by creating `StaleKeysConstants` for shared note message
- Restructure README to place MCP Server documentation before CLI Usage

## Changes
- **Models**: Add `StaleKeysConstants`, `StaleKeysResult`, `FileStaleKeysSummary`, `BatchStaleKeysSummary`
- **XCStringsParser**: Add `getBatchStaleKeys(paths:)` static method
- **MCP**: Add `BatchListStaleHandler` and register in `ToolHandlerRegistry`
- **CLI**: Add `batch stale` subcommand to `BatchCommand`
- **Tests**: Add unit tests for `XCStringsKit` and integration tests for `XCStringsMCP`
- **README**: Add batch stale usage documentation and restructure (MCP → CLI order)

## Test plan
- [x] All 121 existing tests pass
- [x] New batch stale tests verify correct behavior across multiple files
- [x] Empty file list returns empty result
- [x] Stale note message follows SSoT from `StaleKeysConstants`

🤖 Generated with [Claude Code](https://claude.com/claude-code)