### PR TITLE
fix: Add success flag and omit empty arrays from BatchWriteResult

### DIFF
--- a/Sources/XCStringsKit/Models/XCStrings.swift
+++ b/Sources/XCStringsKit/Models/XCStrings.swift
@@ -328,16 +328,36 @@ package struct BatchTranslationEntry: Codable, Sendable {
 
 /// Result of batch add/update operations
 package struct BatchWriteResult: Codable, Sendable {
+    package let success: Bool
     package let successCount: Int
     package let failedCount: Int
     package let succeeded: [String]
     package let failed: [BatchWriteError]
 
     package init(succeeded: [String], failed: [BatchWriteError]) {
+        self.success = failed.isEmpty
         self.successCount = succeeded.count
         self.failedCount = failed.count
         self.succeeded = succeeded
         self.failed = failed
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case success, successCount, failedCount, succeeded, failed
+    }
+
+    package func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(success, forKey: .success)
+        try container.encode(successCount, forKey: .successCount)
+        try container.encode(failedCount, forKey: .failedCount)
+        // Only include non-empty arrays
+        if !succeeded.isEmpty {
+            try container.encode(succeeded, forKey: .succeeded)
+        }
+        if !failed.isEmpty {
+            try container.encode(failed, forKey: .failed)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `success: Bool` field to `BatchWriteResult` (true when no failures)
- Add custom `encode` method to exclude empty arrays from JSON output
- When `failedCount` is 0, the `failed` array is omitted
- When `successCount` is 0, the `succeeded` array is omitted

## Before
```json
{
  "failed": [],
  "failedCount": 0,
  "succeeded": ["Key1", "Key2"],
  "successCount": 2
}
```

## After
```json
{
  "success": true,
  "failedCount": 0,
  "succeeded": ["Key1", "Key2"],
  "successCount": 2
}
```

## Test plan
- [x] Existing batch operations tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)