### PR TITLE
Fix decoding failure for plural and device variations

### DIFF
--- a/Sources/XCStringsKit/Models/XCStrings.swift
+++ b/Sources/XCStringsKit/Models/XCStrings.swift
@@ -59,22 +59,32 @@ package struct Variations: Codable, Sendable {
     }
 }
 
+/// Wrapper for a variation category value (e.g. each plural form or device category)
+/// In xcstrings JSON, each variation value is `{ "stringUnit": { "state": "...", "value": "..." } }`
+package struct VariationValue: Codable, Sendable {
+    var stringUnit: StringUnit?
+
+    package init(stringUnit: StringUnit? = nil) {
+        self.stringUnit = stringUnit
+    }
+}
+
 /// Plural variation
 package struct PluralVariation: Codable, Sendable {
-    var zero: StringUnit?
-    var one: StringUnit?
-    var two: StringUnit?
-    var few: StringUnit?
-    var many: StringUnit?
-    var other: StringUnit?
+    var zero: VariationValue?
+    var one: VariationValue?
+    var two: VariationValue?
+    var few: VariationValue?
+    var many: VariationValue?
+    var other: VariationValue?
 
     package init(
-        zero: StringUnit? = nil,
-        one: StringUnit? = nil,
-        two: StringUnit? = nil,
-        few: StringUnit? = nil,
-        many: StringUnit? = nil,
-        other: StringUnit? = nil
+        zero: VariationValue? = nil,
+        one: VariationValue? = nil,
+        two: VariationValue? = nil,
+        few: VariationValue? = nil,
+        many: VariationValue? = nil,
+        other: VariationValue? = nil
     ) {
         self.zero = zero
         self.one = one
@@ -87,18 +97,18 @@ package struct PluralVariation: Codable, Sendable {
 
 /// Device variation
 package struct DeviceVariation: Codable, Sendable {
-    var iphone: StringUnit?
-    var ipad: StringUnit?
-    var mac: StringUnit?
-    var applewatch: StringUnit?
-    var appletv: StringUnit?
+    var iphone: VariationValue?
+    var ipad: VariationValue?
+    var mac: VariationValue?
+    var applewatch: VariationValue?
+    var appletv: VariationValue?
 
     package init(
-        iphone: StringUnit? = nil,
-        ipad: StringUnit? = nil,
-        mac: StringUnit? = nil,
-        applewatch: StringUnit? = nil,
-        appletv: StringUnit? = nil
+        iphone: VariationValue? = nil,
+        ipad: VariationValue? = nil,
+        mac: VariationValue? = nil,
+        applewatch: VariationValue? = nil,
+        appletv: VariationValue? = nil
     ) {
         self.iphone = iphone
         self.ipad = ipad

--- a/Tests/XCStringsKitTests/FixtureType.swift
+++ b/Tests/XCStringsKitTests/FixtureType.swift
@@ -16,6 +16,8 @@ enum FixtureType: String, CaseIterable, CustomTestStringConvertible {
     case emptyLocalizations
     case manyLanguages
     case variousStates
+    case pluralVariations
+    case deviceVariations
     case withStaleKeys
 
     var testDescription: String { rawValue }
@@ -33,6 +35,8 @@ enum FixtureType: String, CaseIterable, CustomTestStringConvertible {
         case .emptyLocalizations: TestFixtures.emptyLocalizations
         case .manyLanguages: TestFixtures.manyLanguages
         case .variousStates: TestFixtures.variousStates
+        case .pluralVariations: TestFixtures.pluralVariations
+        case .deviceVariations: TestFixtures.deviceVariations
         case .withStaleKeys: TestFixtures.withStaleKeys
         }
     }
@@ -50,6 +54,8 @@ enum FixtureType: String, CaseIterable, CustomTestStringConvertible {
         case .emptyLocalizations: 2
         case .manyLanguages: 1
         case .variousStates: 3
+        case .pluralVariations: 2
+        case .deviceVariations: 1
         case .withStaleKeys: 4
         }
     }

--- a/Tests/XCStringsKitTests/TestFixtures.swift
+++ b/Tests/XCStringsKitTests/TestFixtures.swift
@@ -317,6 +317,92 @@ enum TestFixtures {
     }
     """
 
+    /// Keys with plural variations
+    static let pluralVariations = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "%lld items": {
+          "localizations": {
+            "en": {
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld item"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld items"
+                    }
+                  }
+                }
+              }
+            },
+            "ja": {
+              "variations": {
+                "plural": {
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld個のアイテム"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "Hello": {
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Hello"
+              }
+            }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
+    /// Keys with device variations
+    static let deviceVariations = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "Start": {
+          "localizations": {
+            "en": {
+              "variations": {
+                "device": {
+                  "iphone": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "Tap to start"
+                    }
+                  },
+                  "mac": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "Click to start"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
     /// Keys with stale extraction state
     static let withStaleKeys = """
     {


### PR DESCRIPTION
## Summary

- Fixed `PluralVariation` and `DeviceVariation` field types from `StringUnit?` to `VariationValue?` to match the actual xcstrings JSON format where each variation value is wrapped in a `{ "stringUnit": { ... } }` envelope
- Added `VariationValue` wrapper struct for correct decoding
- Added plural and device variation test fixtures to prevent regression

Closes #16

## Root Cause

The xcstrings format wraps each plural form (`one`, `other`, etc.) and device category (`iphone`, `mac`, etc.) in `{ "stringUnit": { "state": "...", "value": "..." } }`, but the model expected bare `StringUnit` (with `state` and `value` at the top level). This caused `JSONDecoder` to throw a `DecodingError`, which was caught and re-thrown as `invalidFileFormat`.

## Test plan

- [x] All 121 existing tests pass
- [x] New `pluralVariations` and `deviceVariations` fixtures added to `FixtureType` (auto-included in all parameterized tests via `CaseIterable`)
- [x] Manually verified `stats coverage`, `list keys`, and `get key` commands against a plural-variation xcstrings file

🤖 Generated with [Claude Code](https://claude.com/claude-code)