### PR TITLE
feat: Add optional --path argument to mcp server

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,5 +47,9 @@ let package = Package(
             name: "XCStringsKitTests",
             dependencies: ["XCStringsKit"]
         ),
+        .testTarget(
+            name: "XCStringsMCPTests",
+            dependencies: ["XCStringsMCP", "XCStringsKit"]
+        ),
     ]
 )

--- a/Sources/XCStringsCLI/MCPCommand.swift
+++ b/Sources/XCStringsCLI/MCPCommand.swift
@@ -8,8 +8,11 @@ struct MCPCommand: AsyncParsableCommand {
         abstract: "Start the MCP server"
     )
 
+    @Option(name: .long, help: "Default path to the xcstrings file")
+    var path: String?
+
     func run() async throws {
-        let server = XCStringsMCPServer()
+        let server = XCStringsMCPServer(defaultPath: path)
         try await server.run()
     }
 }

--- a/Sources/XCStringsMCP/MCPServer.swift
+++ b/Sources/XCStringsMCP/MCPServer.swift
@@ -35,7 +35,7 @@ public struct XCStringsMCPServer {
 
     // MARK: - Tool Definitions
 
-    private var allTools: [Tool] {
+    var allTools: [Tool] {
         var tools = [
             // Read operations
             Tool(
@@ -368,6 +368,7 @@ public struct XCStringsMCPServer {
 
         if defaultPath != nil {
             for i in 0..<tools.count {
+                guard tools[i].name != "xcstrings_create_file" else { continue }
                 if case .object(var schema) = tools[i].inputSchema,
                    case .array(let requiredParams) = schema["required"] {
                     schema["required"] = .array(requiredParams.filter { $0 != .string("file") && $0 != .string("files") })
@@ -384,17 +385,21 @@ public struct XCStringsMCPServer {
 
     // MARK: - Tool Call Handler
 
+    func resolvedArguments(_ args: [String: Value], toolName: String) -> [String: Value] {
+        var resolved = args
+        guard toolName != "xcstrings_create_file" else { return resolved }
+        if resolved["file"] == nil, let defaultPath {
+            resolved["file"] = .string(defaultPath)
+        }
+        if resolved["files"] == nil, let defaultPath {
+            resolved["files"] = .array([.string(defaultPath)])
+        }
+        return resolved
+    }
+
     private func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
         do {
-            var args = params.arguments ?? [:]
-            
-            if args["file"] == nil, let defaultPath = defaultPath {
-                args["file"] = .string(defaultPath)
-            }
-            if args["files"] == nil, let defaultPath = defaultPath {
-                args["files"] = .array([.string(defaultPath)])
-            }
-
+            let args = resolvedArguments(params.arguments ?? [:], toolName: params.name)
             let result = try await ToolHandlerRegistry.shared.execute(toolName: params.name, arguments: args)
             return .init(content: [.text(result)], isError: false)
         } catch {

--- a/Sources/XCStringsMCP/MCPServer.swift
+++ b/Sources/XCStringsMCP/MCPServer.swift
@@ -3,7 +3,11 @@ import MCP
 import XCStringsKit
 
 public struct XCStringsMCPServer {
-    public init() {}
+    private let defaultPath: String?
+
+    public init(defaultPath: String? = nil) {
+        self.defaultPath = defaultPath
+    }
 
     public func run() async throws {
         let server = Server(
@@ -16,12 +20,12 @@ public struct XCStringsMCPServer {
 
         // Register tool list handler
         await server.withMethodHandler(ListTools.self) { _ in
-            .init(tools: Self.allTools)
+            .init(tools: self.allTools)
         }
 
         // Register tool call handler
         await server.withMethodHandler(CallTool.self) { params in
-            await Self.handleToolCall(params)
+            await self.handleToolCall(params)
         }
 
         let transport = StdioTransport()
@@ -31,8 +35,8 @@ public struct XCStringsMCPServer {
 
     // MARK: - Tool Definitions
 
-    private static var allTools: [Tool] {
-        [
+    private var allTools: [Tool] {
+        var tools = [
             // Read operations
             Tool(
                 name: "xcstrings_list_keys",
@@ -361,13 +365,36 @@ public struct XCStringsMCPServer {
                 ])
             ),
         ]
+
+        if defaultPath != nil {
+            for i in 0..<tools.count {
+                if case .object(var schema) = tools[i].inputSchema,
+                   case .array(let requiredParams) = schema["required"] {
+                    schema["required"] = .array(requiredParams.filter { $0 != .string("file") && $0 != .string("files") })
+                    tools[i] = Tool(
+                        name: tools[i].name,
+                        description: tools[i].description,
+                        inputSchema: .object(schema)
+                    )
+                }
+            }
+        }
+        return tools
     }
 
     // MARK: - Tool Call Handler
 
-    private static func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
+    private func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
         do {
-            let args = params.arguments ?? [:]
+            var args = params.arguments ?? [:]
+            
+            if args["file"] == nil, let defaultPath = defaultPath {
+                args["file"] = .string(defaultPath)
+            }
+            if args["files"] == nil, let defaultPath = defaultPath {
+                args["files"] = .array([.string(defaultPath)])
+            }
+
             let result = try await ToolHandlerRegistry.shared.execute(toolName: params.name, arguments: args)
             return .init(content: [.text(result)], isError: false)
         } catch {

--- a/Tests/XCStringsMCPTests/MCPServerTests.swift
+++ b/Tests/XCStringsMCPTests/MCPServerTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import MCP
+import Testing
+
+@testable import XCStringsMCP
+
+@Suite("XCStringsMCPServer tests")
+struct MCPServerTests {
+
+    // MARK: - Schema tests (allTools)
+
+    @Test("file is required when no defaultPath")
+    func fileRequiredByDefault() {
+        let server = XCStringsMCPServer()
+        let tool = server.allTools.first { $0.name == "xcstrings_list_keys" }!
+        guard case .object(let schema) = tool.inputSchema,
+              case .array(let required) = schema["required"] else {
+            Issue.record("Unexpected schema structure")
+            return
+        }
+        #expect(required.contains(.string("file")))
+    }
+
+    @Test("files is required when no defaultPath")
+    func filesRequiredByDefault() {
+        let server = XCStringsMCPServer()
+        let tool = server.allTools.first { $0.name == "xcstrings_batch_list_stale" }!
+        guard case .object(let schema) = tool.inputSchema,
+              case .array(let required) = schema["required"] else {
+            Issue.record("Unexpected schema structure")
+            return
+        }
+        #expect(required.contains(.string("files")))
+    }
+
+    @Test("file is removed from required when defaultPath is set")
+    func fileRemovedFromRequiredWithDefaultPath() {
+        let server = XCStringsMCPServer(defaultPath: "/default/Localizable.xcstrings")
+        let tool = server.allTools.first { $0.name == "xcstrings_list_keys" }!
+        guard case .object(let schema) = tool.inputSchema,
+              case .array(let required) = schema["required"] else {
+            Issue.record("Unexpected schema structure")
+            return
+        }
+        #expect(!required.contains(.string("file")))
+    }
+
+    @Test("files is removed from required when defaultPath is set")
+    func filesRemovedFromRequiredWithDefaultPath() {
+        let server = XCStringsMCPServer(defaultPath: "/default/Localizable.xcstrings")
+        let tool = server.allTools.first { $0.name == "xcstrings_batch_list_stale" }!
+        guard case .object(let schema) = tool.inputSchema,
+              case .array(let required) = schema["required"] else {
+            Issue.record("Unexpected schema structure")
+            return
+        }
+        #expect(!required.contains(.string("files")))
+    }
+
+    @Test("xcstrings_create_file keeps file required even with defaultPath")
+    func createFileKeepsFileRequired() {
+        let server = XCStringsMCPServer(defaultPath: "/default/Localizable.xcstrings")
+        let tool = server.allTools.first { $0.name == "xcstrings_create_file" }!
+        guard case .object(let schema) = tool.inputSchema,
+              case .array(let required) = schema["required"] else {
+            Issue.record("Unexpected schema structure")
+            return
+        }
+        #expect(required.contains(.string("file")))
+    }
+
+    // MARK: - Arg injection tests (resolvedArguments)
+
+    @Test("injects defaultPath as file when file arg absent")
+    func injectsDefaultPathForFile() {
+        let server = XCStringsMCPServer(defaultPath: "/default/Localizable.xcstrings")
+        let result = server.resolvedArguments([:], toolName: "xcstrings_list_keys")
+        #expect(result["file"] == .string("/default/Localizable.xcstrings"))
+    }
+
+    @Test("does not override explicit file arg")
+    func doesNotOverrideExplicitFile() {
+        let server = XCStringsMCPServer(defaultPath: "/default/Localizable.xcstrings")
+        let args: [String: Value] = ["file": .string("/explicit/path.xcstrings")]
+        let result = server.resolvedArguments(args, toolName: "xcstrings_list_keys")
+        #expect(result["file"] == .string("/explicit/path.xcstrings"))
+    }
+
+    @Test("injects defaultPath as files array for batch tools")
+    func injectsDefaultPathForFiles() {
+        let server = XCStringsMCPServer(defaultPath: "/default/Localizable.xcstrings")
+        let result = server.resolvedArguments([:], toolName: "xcstrings_batch_list_stale")
+        #expect(result["files"] == .array([.string("/default/Localizable.xcstrings")]))
+    }
+
+    @Test("does not override explicit files arg")
+    func doesNotOverrideExplicitFiles() {
+        let server = XCStringsMCPServer(defaultPath: "/default/Localizable.xcstrings")
+        let args: [String: Value] = ["files": .array([.string("/explicit/a.xcstrings"), .string("/explicit/b.xcstrings")])]
+        let result = server.resolvedArguments(args, toolName: "xcstrings_batch_list_stale")
+        #expect(result["files"] == .array([.string("/explicit/a.xcstrings"), .string("/explicit/b.xcstrings")]))
+    }
+
+    @Test("xcstrings_create_file receives no arg injection")
+    func noInjectionForCreateFile() {
+        let server = XCStringsMCPServer(defaultPath: "/default/Localizable.xcstrings")
+        let result = server.resolvedArguments([:], toolName: "xcstrings_create_file")
+        #expect(result["file"] == nil)
+        #expect(result["files"] == nil)
+    }
+
+    @Test("no injection when defaultPath is nil")
+    func noInjectionWithoutDefaultPath() {
+        let server = XCStringsMCPServer()
+        let result = server.resolvedArguments([:], toolName: "xcstrings_list_keys")
+        #expect(result["file"] == nil)
+    }
+}

--- a/Tests/XCStringsMCPTests/TestFixtures.swift
+++ b/Tests/XCStringsMCPTests/TestFixtures.swift
@@ -1,0 +1,455 @@
+import Foundation
+
+/// Test fixtures for xcstrings file testing
+enum TestFixtures {
+    /// Empty xcstrings file
+    static let empty = """
+    {
+      "sourceLanguage": "en",
+      "strings": {},
+      "version": "1.0"
+    }
+    """
+
+    /// Single key with single language
+    static let singleKeySingleLang = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "Hello": {
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Hello"
+              }
+            }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
+    /// Single key with multiple languages
+    static let singleKeyMultipleLangs = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "Hello": {
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Hello"
+              }
+            },
+            "ja": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "こんにちは"
+              }
+            },
+            "de": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Hallo"
+              }
+            }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
+    /// Multiple keys with partial translations
+    static let multipleKeysPartialTranslations = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "Hello": {
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Hello"
+              }
+            },
+            "ja": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "こんにちは"
+              }
+            }
+          }
+        },
+        "Goodbye": {
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Goodbye"
+              }
+            }
+          }
+        },
+        "Welcome": {
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Welcome"
+              }
+            },
+            "ja": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "ようこそ"
+              }
+            },
+            "de": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Willkommen"
+              }
+            }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
+    /// Keys with comments
+    static let withComments = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "Hello": {
+          "comment": "Greeting message shown on home screen",
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Hello"
+              }
+            }
+          }
+        },
+        "Save": {
+          "comment": "Button label for saving data",
+          "extractionState": "manual",
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Save"
+              }
+            }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
+    /// Different source language (Japanese)
+    static let japaneseSource = """
+    {
+      "sourceLanguage": "ja",
+      "strings": {
+        "こんにちは": {
+          "localizations": {
+            "ja": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "こんにちは"
+              }
+            },
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Hello"
+              }
+            }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
+    /// Many keys (10 keys)
+    static let manyKeys = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "Key1": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Value1" } } } },
+        "Key2": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Value2" } } } },
+        "Key3": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Value3" } } } },
+        "Key4": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Value4" } } } },
+        "Key5": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Value5" } } } },
+        "Key6": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Value6" } }, "ja": { "stringUnit": { "state": "translated", "value": "値6" } } } },
+        "Key7": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Value7" } }, "ja": { "stringUnit": { "state": "translated", "value": "値7" } } } },
+        "Key8": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Value8" } }, "ja": { "stringUnit": { "state": "translated", "value": "値8" } } } },
+        "Key9": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Value9" } } } },
+        "Key10": { "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Value10" } } } }
+      },
+      "version": "1.0"
+    }
+    """
+
+    /// Keys with special characters
+    static let specialCharacters = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "Hello, %@!": {
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Hello, %@!"
+              }
+            },
+            "ja": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "こんにちは、%@！"
+              }
+            }
+          }
+        },
+        "Items: %lld": {
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Items: %lld"
+              }
+            }
+          }
+        },
+        "Line1\\\\nLine2": {
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Line1\\\\nLine2"
+              }
+            }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
+    /// Keys with empty localizations
+    static let emptyLocalizations = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "NoTranslation": {
+          "comment": "This key has no translations yet"
+        },
+        "HasTranslation": {
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Has Translation"
+              }
+            }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
+    /// Many languages (5+ languages)
+    static let manyLanguages = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "Hello": {
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Hello" } },
+            "ja": { "stringUnit": { "state": "translated", "value": "こんにちは" } },
+            "de": { "stringUnit": { "state": "translated", "value": "Hallo" } },
+            "fr": { "stringUnit": { "state": "translated", "value": "Bonjour" } },
+            "es": { "stringUnit": { "state": "translated", "value": "Hola" } },
+            "zh-Hans": { "stringUnit": { "state": "translated", "value": "你好" } },
+            "ko": { "stringUnit": { "state": "translated", "value": "안녕하세요" } }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
+    /// Various translation states
+    static let variousStates = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "Translated": {
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Translated" } },
+            "ja": { "stringUnit": { "state": "translated", "value": "翻訳済み" } }
+          }
+        },
+        "NeedsReview": {
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Needs Review" } },
+            "ja": { "stringUnit": { "state": "needs_review", "value": "レビュー必要" } }
+          }
+        },
+        "New": {
+          "localizations": {
+            "en": { "stringUnit": { "state": "new", "value": "New" } }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
+    /// Keys with plural variations
+    static let pluralVariations = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "%lld items": {
+          "localizations": {
+            "en": {
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld item"
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld items"
+                    }
+                  }
+                }
+              }
+            },
+            "ja": {
+              "variations": {
+                "plural": {
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld個のアイテム"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "Hello": {
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Hello"
+              }
+            }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
+    /// Keys with device variations
+    static let deviceVariations = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "Start": {
+          "localizations": {
+            "en": {
+              "variations": {
+                "device": {
+                  "iphone": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "Tap to start"
+                    }
+                  },
+                  "mac": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "Click to start"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
+    /// Keys with stale extraction state
+    static let withStaleKeys = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "ActiveKey": {
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Active" } }
+          }
+        },
+        "StaleKey1": {
+          "extractionState": "stale",
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Stale 1" } }
+          }
+        },
+        "StaleKey2": {
+          "extractionState": "stale",
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Stale 2" } },
+            "ja": { "stringUnit": { "state": "translated", "value": "古い2" } }
+          }
+        },
+        "ManualKey": {
+          "extractionState": "manual",
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Manual" } }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+}
+
+/// Test helper utilities
+enum TestHelper {
+    /// Create a temporary file and return its path
+    static func createTempFile(content: String) throws -> String {
+        let tempDir = FileManager.default.temporaryDirectory
+        let path = tempDir.appendingPathComponent("test_\(UUID().uuidString).xcstrings").path
+        try content.write(toFile: path, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    /// Remove temporary file
+    static func removeTempFile(at path: String) {
+        try? FileManager.default.removeItem(atPath: path)
+    }
+}


### PR DESCRIPTION
Hello! Thank you for creating this useful tool.

I added an optional `--path` argument to the `mcp` command. When a default path is provided upon starting the server, the server automatically removes the `file` and `files` requirements from the MCP tool schemas. When the client calls a tool without specifying a file, the server injects the default path automatically. This makes it much more convenient to use the MCP server in projects that primarily have a single `.xcstrings` file, as the AI assistant no longer needs to deduce or be instructed on the exact file path for every operation.

```
{
  "mcpServers": {
    "xcstrings-crud": {
      "command": "xcstrings-crud",
      "args": [
        "mcp",
        "--path",
        "/abs/path/to/Localizable.xcstrings"
      ]
    }
  }
}
```

Also, as a small note, I found that the project currently requires Swift 5 language mode to compile successfully (`swift build -Xswiftc -swift-version -Xswiftc 5`), as the strict concurrency checking in Swift 6 throws data race errors inside the `swift-sdk` dependency out of the box.

Thank you for your time and for reviewing this PR!