### PR TITLE
Add gitleaks secret scanning

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,11 @@
 #!/bin/sh
 SRCROOT=$(git rev-parse --show-toplevel)
 
+GITLEAKS=$(mise which gitleaks 2>/dev/null || command -v gitleaks 2>/dev/null || true)
+if [ -n "$GITLEAKS" ]; then
+  "$GITLEAKS" protect --staged --source "$SRCROOT" -v
+fi
+
 # docsync: check doc/source sync
 DOCSYNC="$SRCROOT/.nest/bin/docsync"
 if [ -x "$DOCSYNC" ] && [ -f "$SRCROOT/docsync.yml" ]; then

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,13 @@
+name: gitleaks
+on: [pull_request, push, workflow_dispatch]
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -5,7 +5,7 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+gitleaks = "latest"


### PR DESCRIPTION
## Summary

- Add \`.mise.toml\` to manage \`gitleaks\` via mise (resolved from aqua registry)
- Add gitleaks \`protect --staged\` check to \`.githooks/pre-commit\` — runs before each commit, skips silently if not installed
- Add \`.github/workflows/gitleaks.yml\` — CI scan on every PR, push, and \`workflow_dispatch\`

## Setup

\`\`\`bash
mise install   # installs gitleaks
make setup     # configures git hooks
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)