### PR TITLE
Respect non-translatable string catalog entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,9 @@ swift build -c release # Release build
 
 - `XCStrings.swift` - Data models (`StringCatalog`, `StringUnit`, etc.)
 - `XCStringsParser.swift` - Facade for file operations
-- `XCStringsReader.swift` - Read operations (list, get, check)
+- `XCStringsReader.swift` - Read operations (list, get, check), including `shouldTranslate == false` handling for untranslated lists and per-key coverage
 - `XCStringsWriter.swift` - Write operations (add, update, delete, rename)
-- `XCStringsStatsCalculator.swift` - Coverage and progress stats
+- `XCStringsStatsCalculator.swift` - Coverage and progress stats; non-translatable keys are excluded from language totals
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This tool provides a **token-efficient** approach by offering targeted CRUD oper
 - **Query only what you need**: Fetch specific keys or languages instead of loading the entire file
 - **Incremental updates**: Add or update individual translations without reading the full content
 - **Quick stats**: Get coverage and progress summaries without parsing all entries
+- **String Catalog semantics**: Preserve Xcode metadata such as `shouldTranslate`, and exclude non-translatable keys from untranslated lists and coverage totals
 
 By using the MCP server or CLI, AI assistants can work with xcstrings files of any size while keeping token usage minimal.
 
@@ -115,6 +116,7 @@ xcstrings-crud list languages --file path/to/Localizable.xcstrings
 
 # List untranslated keys for a language
 xcstrings-crud list untranslated --file path/to/Localizable.xcstrings --lang ja
+# Keys marked `"shouldTranslate": false` are omitted from untranslated results.
 
 # List stale keys (potentially unused)
 xcstrings-crud list stale --file path/to/Localizable.xcstrings
@@ -134,9 +136,11 @@ xcstrings-crud check key "Hello" --file path/to/Localizable.xcstrings
 
 # Check key coverage
 xcstrings-crud check coverage "Hello" --file path/to/Localizable.xcstrings
+# Non-translatable keys are treated as complete.
 
 # Get overall statistics
 xcstrings-crud stats coverage --file path/to/Localizable.xcstrings
+# Coverage totals exclude keys marked `"shouldTranslate": false`.
 
 # Get progress for a language
 xcstrings-crud stats progress --file path/to/Localizable.xcstrings --lang ja

--- a/Sources/XCStringsKit/Models/XCStrings.swift
+++ b/Sources/XCStringsKit/Models/XCStrings.swift
@@ -17,11 +17,22 @@ package struct XCStringsFile: Codable {
 package struct StringEntry: Codable {
     var comment: String?
     var extractionState: String?
+    var shouldTranslate: Bool?
     var localizations: [String: Localization]?
 
-    package init(comment: String? = nil, extractionState: String? = nil, localizations: [String: Localization]? = nil) {
+    var requiresTranslation: Bool {
+        shouldTranslate != false
+    }
+
+    package init(
+        comment: String? = nil,
+        extractionState: String? = nil,
+        shouldTranslate: Bool? = nil,
+        localizations: [String: Localization]? = nil
+    ) {
         self.comment = comment
         self.extractionState = extractionState
+        self.shouldTranslate = shouldTranslate
         self.localizations = localizations
     }
 }
@@ -125,12 +136,14 @@ package struct KeyInfo: Codable {
     package let key: String
     package let comment: String?
     package let extractionState: String?
+    package let shouldTranslate: Bool?
     package let languages: [String]
 
-    package init(key: String, comment: String?, extractionState: String?, languages: [String]) {
+    package init(key: String, comment: String?, extractionState: String?, shouldTranslate: Bool?, languages: [String]) {
         self.key = key
         self.comment = comment
         self.extractionState = extractionState
+        self.shouldTranslate = shouldTranslate
         self.languages = languages
     }
 }

--- a/Sources/XCStringsKit/XCStringsReader.swift
+++ b/Sources/XCStringsKit/XCStringsReader.swift
@@ -25,6 +25,10 @@ struct XCStringsReader {
     func listUntranslated(for language: String) -> [String] {
         file.strings
             .filter { _, entry in
+                guard entry.requiresTranslation else {
+                    return false
+                }
+
                 let localization = entry.localizations?[language]
                 return localization?.stringUnit?.value == nil && localization?.variations == nil
             }
@@ -57,6 +61,7 @@ struct XCStringsReader {
             key: key,
             comment: entry.comment,
             extractionState: entry.extractionState,
+            shouldTranslate: entry.shouldTranslate,
             languages: languages
         )
     }
@@ -121,6 +126,15 @@ struct XCStringsReader {
 
         guard let entry = file.strings[key] else {
             throw XCStringsError.keyNotFound(key: key)
+        }
+
+        guard entry.requiresTranslation else {
+            return CoverageInfo(
+                key: key,
+                translatedLanguages: [],
+                missingLanguages: [],
+                coveragePercent: 100
+            )
         }
 
         let translatedLanguages = entry.localizations?.keys.sorted() ?? []

--- a/Sources/XCStringsKit/XCStringsStatsCalculator.swift
+++ b/Sources/XCStringsKit/XCStringsStatsCalculator.swift
@@ -13,15 +13,15 @@ struct XCStringsStatsCalculator {
     /// Get overall statistics
     func getStats() -> StatsInfo {
         let allLanguages = reader.listLanguages()
-        let entries = file.strings.values
+        let translatableEntries = file.strings.values.filter(\.requiresTranslation)
 
         let coverageByLanguage = Dictionary(uniqueKeysWithValues: allLanguages.lazy.map { language in
-            let translated = entries.lazy.count(where: { entry in
+            let translated = translatableEntries.lazy.count(where: { entry in
                 let localization = entry.localizations?[language]
                 return localization?.stringUnit?.value != nil || localization?.variations != nil
             })
 
-            let total = entries.count
+            let total = translatableEntries.count
             let untranslated = total - translated
             let coveragePercent = total == 0 ? 0 : Double(translated) / Double(total) * 100
 

--- a/Tests/XCStringsKitTests/GetOperationsTests.swift
+++ b/Tests/XCStringsKitTests/GetOperationsTests.swift
@@ -59,4 +59,16 @@ struct GetOperationsTests {
             _ = try await parser.getTranslation(key: "NonExistentKey", language: nil)
         }
     }
+
+    @Test("getKey returns shouldTranslate metadata")
+    func getKeyShouldTranslate() async throws {
+        let path = try TestHelper.createTempFile(content: TestFixtures.withNonTranslatableKey)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let info = try await parser.getKey("BrandName")
+
+        #expect(info.shouldTranslate == false)
+        #expect(info.comment == "Product name")
+    }
 }

--- a/Tests/XCStringsKitTests/ListOperationsTests.swift
+++ b/Tests/XCStringsKitTests/ListOperationsTests.swift
@@ -60,6 +60,17 @@ struct ListOperationsTests {
         #expect(untranslated == expectedKeys)
     }
 
+    @Test("listUntranslated excludes keys marked shouldTranslate false")
+    func listUntranslatedExcludesNonTranslatableKeys() async throws {
+        let path = try TestHelper.createTempFile(content: TestFixtures.withNonTranslatableKey)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let untranslated = try await parser.listUntranslated(for: "ja")
+
+        #expect(untranslated == ["Greeting"])
+    }
+
     @Test("listStaleKeys returns keys with stale extraction state")
     func listStaleKeys() async throws {
         let path = try TestHelper.createTempFile(content: TestFixtures.withStaleKeys)

--- a/Tests/XCStringsKitTests/StatsOperationsTests.swift
+++ b/Tests/XCStringsKitTests/StatsOperationsTests.swift
@@ -42,4 +42,18 @@ struct StatsOperationsTests {
         #expect(progress.translated == translated)
         #expect(progress.untranslated == untranslated)
     }
+
+    @Test("getProgress excludes keys marked shouldTranslate false")
+    func getProgressExcludesNonTranslatableKeys() async throws {
+        let path = try TestHelper.createTempFile(content: TestFixtures.withNonTranslatableKey)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let parser = XCStringsParser(path: path)
+        let progress = try await parser.getProgress(for: "en")
+
+        #expect(progress.translated == 1)
+        #expect(progress.untranslated == 0)
+        #expect(progress.total == 1)
+        #expect(progress.coveragePercent == 100.0)
+    }
 }

--- a/Tests/XCStringsKitTests/TestFixtures.swift
+++ b/Tests/XCStringsKitTests/TestFixtures.swift
@@ -269,6 +269,30 @@ enum TestFixtures {
     }
     """
 
+    /// Key marked as not requiring translation
+    static let withNonTranslatableKey = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "BrandName": {
+          "comment": "Product name",
+          "shouldTranslate": false
+        },
+        "Greeting": {
+          "localizations": {
+            "en": {
+              "stringUnit": {
+                "state": "translated",
+                "value": "Hello"
+              }
+            }
+          }
+        }
+      },
+      "version": "1.1"
+    }
+    """
+
     /// Many languages (5+ languages)
     static let manyLanguages = """
     {

--- a/Tests/XCStringsKitTests/XCStringsReaderTests.swift
+++ b/Tests/XCStringsKitTests/XCStringsReaderTests.swift
@@ -65,6 +65,17 @@ struct XCStringsReaderTests {
         #expect(untranslated.contains("Goodbye"))
     }
 
+    @Test("listUntranslated excludes keys marked shouldTranslate false")
+    func listUntranslatedExcludesNonTranslatableKeys() throws {
+        let file = try loadFixture(TestFixtures.withNonTranslatableKey)
+        let reader = XCStringsReader(file: file)
+
+        let untranslated = reader.listUntranslated(for: "ja")
+
+        #expect(!untranslated.contains("BrandName"))
+        #expect(untranslated.contains("Greeting"))
+    }
+
     // MARK: - getSourceLanguage
 
     @Test("getSourceLanguage returns correct language")
@@ -88,6 +99,17 @@ struct XCStringsReaderTests {
 
         #expect(info.key == "Hello")
         #expect(info.comment == "Greeting message shown on home screen")
+    }
+
+    @Test("getKey returns shouldTranslate metadata")
+    func getKeyShouldTranslate() throws {
+        let file = try loadFixture(TestFixtures.withNonTranslatableKey)
+        let reader = XCStringsReader(file: file)
+
+        let info = try reader.getKey("BrandName")
+
+        #expect(info.shouldTranslate == false)
+        #expect(info.comment == "Product name")
     }
 
     @Test("getKey throws for non-existent key")
@@ -167,6 +189,18 @@ struct XCStringsReaderTests {
 
         #expect(coverage.key == "Hello")
         #expect(coverage.translatedLanguages.count == 3)
+        #expect(coverage.coveragePercent == 100.0)
+    }
+
+    @Test("checkCoverage treats shouldTranslate false keys as complete")
+    func checkCoverageNonTranslatableKey() throws {
+        let file = try loadFixture(TestFixtures.withNonTranslatableKey)
+        let reader = XCStringsReader(file: file)
+
+        let coverage = try reader.checkCoverage("BrandName")
+
+        #expect(coverage.translatedLanguages.isEmpty)
+        #expect(coverage.missingLanguages.isEmpty)
         #expect(coverage.coveragePercent == 100.0)
     }
 

--- a/Tests/XCStringsKitTests/XCStringsStatsCalculatorTests.swift
+++ b/Tests/XCStringsKitTests/XCStringsStatsCalculatorTests.swift
@@ -77,6 +77,21 @@ struct XCStringsStatsCalculatorTests {
         #expect(try #require(enStats?.translated) >= jaStats!.translated)
     }
 
+    @Test("getStats excludes keys marked shouldTranslate false from coverage totals")
+    func getStatsExcludesNonTranslatableKeys() throws {
+        let file = try loadFixture(TestFixtures.withNonTranslatableKey)
+        let calculator = XCStringsStatsCalculator(file: file)
+
+        let stats = calculator.getStats()
+        let enStats = stats.coverageByLanguage["en"]
+
+        #expect(stats.totalKeys == 2)
+        #expect(enStats?.translated == 1)
+        #expect(enStats?.untranslated == 0)
+        #expect(enStats?.total == 1)
+        #expect(enStats?.coveragePercent == 100.0)
+    }
+
     // MARK: - getProgress
 
     @Test("getProgress returns stats for specific language")

--- a/docsync.yml
+++ b/docsync.yml
@@ -40,7 +40,7 @@ rules:
   doc: README.md
   message: "Core data model or error types changed \u2014 update README if the behavior
     or output format changed."
-  checksum: 1797b6cc488b43d38c47c798f8200d71917f8735f968daf62ca76b1d5a69e9d8
+  checksum: 25796f9c02f3e4cade48e914a0155bbaca93feefbd322ba6fb0063abac2d6fa4
 - name: agents-claude
   sources:
   - Package.swift
@@ -50,4 +50,4 @@ rules:
   doc: CLAUDE.md
   message: "Core architecture changed \u2014 update CLAUDE.md if the architecture
     description is affected."
-  checksum: 55fdde9f5050a45f783e66889025384f99dc1845b4a4c1bedfebc141b935e780
+  checksum: 7b911c08e1a0b5580005662a5f536a7f8fad04114ebf0247a9096cea9de722b3


### PR DESCRIPTION
## Summary

- Add `shouldTranslate` support to string catalog entries.
- Exclude entries marked `shouldTranslate: false` from untranslated listings and coverage/progress totals.
- Return `shouldTranslate` metadata from key lookup results.

## Context

Addresses the `shouldTranslate: false` portion of #18.

## Testing

- `swift test`