### PR TITLE
Add untranslated string check command for coding agents

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,2 @@
 [features]
-codex_hooks = true
+hooks = true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,8 @@ swift build -c release # Release build
 ## Key Files
 
 - `XCStrings.swift` - Data models (`StringCatalog`, `StringUnit`, Xcode metadata fields, etc.)
-- `XCStringsParser.swift` - Facade for file operations
-- `XCStringsReader.swift` - Read operations (list, get, check), including key metadata and `shouldTranslate == false` handling for untranslated lists and per-key coverage
+- `XCStringsParser.swift` - Facade for file operations, including multi-file untranslated checks
+- `XCStringsReader.swift` - Read operations (list, get, check), including key metadata, `shouldTranslate == false` handling, and untranslated issue detection for specific files and languages
 - `XCStringsWriter.swift` - Write operations (add, update, delete, rename)
 - `XCStringsFileEncoder.swift` - Deterministic xcstrings JSON encoding with Xcode-like key order
 - `XCStringsKeySorter.swift` - Xcode-like natural sorting for string catalog keys

--- a/Package.swift
+++ b/Package.swift
@@ -47,5 +47,12 @@ let package = Package(
             name: "XCStringsKitTests",
             dependencies: ["XCStringsKit"]
         ),
+        .testTarget(
+            name: "XCStringsCLITests",
+            dependencies: [
+                "XCStringsCLI",
+                "XCStringsKit",
+            ]
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -139,6 +139,23 @@ xcstrings-crud check key "Hello" --file path/to/Localizable.xcstrings
 xcstrings-crud check coverage "Hello" --file path/to/Localizable.xcstrings
 # Non-translatable keys are treated as complete.
 
+# Check untranslated entries across specific files and languages
+xcstrings-crud check untranslated \
+  --files App/Localizable.xcstrings Package/Localizable.xcstrings \
+  --languages ja de fr
+# Emits JSON and exits with status 1 when untranslated entries are found.
+# Keys marked `"shouldTranslate": false` are omitted from untranslated results.
+
+# Emit hook-compatible blocking JSON instead of failing the command.
+xcstrings-crud check untranslated \
+  --files App/Localizable.xcstrings \
+  --languages ja \
+  --codex-hook
+xcstrings-crud check untranslated \
+  --files App/Localizable.xcstrings \
+  --languages ja \
+  --claude-hook
+
 # Get overall statistics
 xcstrings-crud stats coverage --file path/to/Localizable.xcstrings
 # Coverage totals exclude keys marked `"shouldTranslate": false`.
@@ -213,6 +230,8 @@ xcstrings-crud batch update --file path/to/Localizable.xcstrings \
 
 - `--file <path>`: xcstrings file path (required)
 - `--pretty`: Pretty-printed JSON output
+
+For `check untranslated`, `--files <paths...>` and `--languages <codes...>` are required. `--codex-hook` and `--claude-hook` are mutually exclusive and intended for CLI hook integrations only.
 
 ## Requirements
 

--- a/Sources/XCStringsCLI/CheckCommand.swift
+++ b/Sources/XCStringsCLI/CheckCommand.swift
@@ -6,7 +6,7 @@ struct CheckCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "check",
         abstract: "Check key existence or coverage",
-        subcommands: [Key.self, Coverage.self]
+        subcommands: [Key.self, Coverage.self, Untranslated.self]
     )
 }
 
@@ -54,4 +54,124 @@ extension CheckCommand {
             try CLIOutput.printJSON(coverage, pretty: pretty)
         }
     }
+
+    struct Untranslated: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "untranslated",
+            abstract: "Check untranslated strings across xcstrings files"
+        )
+
+        @Option(name: [.short, .long], parsing: .upToNextOption, help: "Paths to xcstrings files")
+        var files: [String]
+
+        @Option(name: [.customShort("l"), .customLong("languages")], parsing: .upToNextOption, help: "Language codes to check")
+        var languages: [String]
+
+        @Flag(name: .long, help: "Output in pretty-printed JSON format")
+        var pretty = false
+
+        @Flag(name: .long, help: "Emit Codex PostToolUse hook JSON to stdout and exit 0. Mutually exclusive with --claude-hook.")
+        var codexHook = false
+
+        @Flag(name: .long, help: "Emit Claude hook JSON to stdout and exit 0. Mutually exclusive with --codex-hook.")
+        var claudeHook = false
+
+        func validate() throws {
+            if files.isEmpty {
+                throw ValidationError("At least one file must be specified")
+            }
+            if languages.isEmpty {
+                throw ValidationError("At least one language must be specified")
+            }
+            if codexHook, claudeHook {
+                throw ValidationError("--codex-hook and --claude-hook are mutually exclusive.")
+            }
+        }
+
+        func run() async throws {
+            let result = try XCStringsParser.checkUntranslated(paths: files, languages: languages)
+
+            if codexHook {
+                try printCodexHookOutput(for: result)
+                return
+            }
+
+            if claudeHook {
+                try printClaudeHookOutput(for: result)
+                return
+            }
+
+            try CLIOutput.printJSON(result, pretty: pretty)
+
+            if !result.isComplete {
+                throw ExitCode(1)
+            }
+        }
+
+        func codexHookOutput(for result: UntranslatedCheckResult) -> CodexPostToolUseHookOutput? {
+            guard !result.isComplete else {
+                return nil
+            }
+
+            return CodexPostToolUseHookOutput(reason: hookReason(for: result))
+        }
+
+        func claudeHookOutput(for result: UntranslatedCheckResult) -> ClaudeHookOutput? {
+            guard !result.isComplete else {
+                return nil
+            }
+
+            return ClaudeHookOutput(reason: hookReason(for: result))
+        }
+
+        private func printCodexHookOutput(for result: UntranslatedCheckResult) throws {
+            guard let output = codexHookOutput(for: result) else {
+                return
+            }
+
+            try CLIOutput.printJSON(
+                output,
+                pretty: false
+            )
+        }
+
+        private func printClaudeHookOutput(for result: UntranslatedCheckResult) throws {
+            guard let output = claudeHookOutput(for: result) else {
+                return
+            }
+
+            try CLIOutput.printJSON(
+                output,
+                pretty: false
+            )
+        }
+
+        private func hookReason(for result: UntranslatedCheckResult) -> String {
+            let lines = result.issues.map { issue in
+                "\(issue.file): \(issue.language): \(issue.key) (\(issue.reason.message(state: issue.state)))"
+            }
+            return "Untranslated strings found:\n" + lines.joined(separator: "\n")
+        }
+    }
+}
+
+struct CodexPostToolUseHookOutput: Encodable {
+    let decision = "block"
+    let reason: String
+    let hookSpecificOutput: HookSpecificOutput
+
+    init(reason: String) {
+        self.reason = reason
+        hookSpecificOutput = HookSpecificOutput()
+    }
+
+    struct HookSpecificOutput: Encodable {
+        let hookEventName = "PostToolUse"
+        let additionalContext = "Fix the listed untranslated strings before continuing."
+    }
+}
+
+struct ClaudeHookOutput: Encodable {
+    let decision = "block"
+    let reason: String
 }

--- a/Sources/XCStringsKit/Models/XCStrings.swift
+++ b/Sources/XCStringsKit/Models/XCStrings.swift
@@ -71,6 +71,22 @@ package struct Variations: Codable {
         self.plural = plural
         self.device = device
     }
+
+    var allValues: [VariationValue] {
+        [
+            plural?.zero,
+            plural?.one,
+            plural?.two,
+            plural?.few,
+            plural?.many,
+            plural?.other,
+            device?.iphone,
+            device?.ipad,
+            device?.mac,
+            device?.applewatch,
+            device?.appletv,
+        ].compactMap(\.self)
+    }
 }
 
 /// Wrapper for a variation category value (e.g. each plural form or device category)
@@ -219,6 +235,69 @@ package struct LanguageStats: Codable {
         self.untranslated = untranslated
         self.total = total
         self.coveragePercent = coveragePercent
+    }
+}
+
+/// A single untranslated entry found in an xcstrings file.
+package struct UntranslatedIssue: Codable, Equatable {
+    package let file: String
+    package let language: String
+    package let key: String
+    package let reason: UntranslatedReason
+    package let state: String?
+
+    package init(file: String, language: String, key: String, reason: UntranslatedReason, state: String? = nil) {
+        self.file = file
+        self.language = language
+        self.key = key
+        self.reason = reason
+        self.state = state
+    }
+}
+
+/// Stable machine-readable reason for an untranslated issue.
+package enum UntranslatedReason: String, Codable, Equatable {
+    case missingLocalization
+    case emptyValue
+    case stateNotTranslated
+    case missingStringUnit
+    case missingVariationValues
+    case missingVariationStringUnit
+    case emptyVariationValue
+    case variationStateNotTranslated
+
+    package func message(state: String?) -> String {
+        switch self {
+        case .missingLocalization:
+            "missing localization"
+        case .emptyValue:
+            "empty value"
+        case .stateNotTranslated:
+            "state is \(state ?? "unknown")"
+        case .missingStringUnit:
+            "missing string unit"
+        case .missingVariationValues:
+            "missing variation values"
+        case .missingVariationStringUnit:
+            "missing variation string unit"
+        case .emptyVariationValue:
+            "empty variation value"
+        case .variationStateNotTranslated:
+            "variation state is \(state ?? "unknown")"
+        }
+    }
+}
+
+/// Result of checking untranslated entries across one or more xcstrings files.
+package struct UntranslatedCheckResult: Codable, Equatable {
+    package let issues: [UntranslatedIssue]
+
+    package var isComplete: Bool {
+        issues.isEmpty
+    }
+
+    package init(issues: [UntranslatedIssue]) {
+        self.issues = issues
     }
 }
 

--- a/Sources/XCStringsKit/XCStringsParser.swift
+++ b/Sources/XCStringsKit/XCStringsParser.swift
@@ -155,6 +155,16 @@ package actor XCStringsParser {
         return BatchStaleKeysSummary(files: fileSummaries)
     }
 
+    /// Check untranslated entries across multiple files and languages.
+    package static func checkUntranslated(paths: [String], languages: [String]) throws -> UntranslatedCheckResult {
+        let issues = try paths.sorted().flatMap { path in
+            let handler = XCStringsFileHandler(path: path)
+            let file = try handler.load()
+            return XCStringsReader(file: file).checkUntranslated(file: path, languages: languages)
+        }
+        return UntranslatedCheckResult(issues: issues)
+    }
+
     // MARK: - Write Operations
 
     /// Add a translation

--- a/Sources/XCStringsKit/XCStringsReader.swift
+++ b/Sources/XCStringsKit/XCStringsReader.swift
@@ -36,6 +36,24 @@ struct XCStringsReader {
             .withXcodeSort()
     }
 
+    /// Check untranslated entries for hook/CI usage.
+    func checkUntranslated(file path: String, languages: [String]) -> [UntranslatedIssue] {
+        let sortedLanguages = Set(languages).sorted()
+        let sortedKeys = file.strings.keys.withXcodeSort()
+
+        return sortedLanguages.flatMap { language in
+            sortedKeys.compactMap { key in
+                guard let entry = file.strings[key], entry.requiresTranslation else { return nil }
+                return untranslatedIssue(
+                    file: path,
+                    language: language,
+                    key: key,
+                    localization: entry.localizations?[language]
+                )
+            }
+        }
+    }
+
     /// Get keys with stale extraction state
     func listStaleKeys() -> [String] {
         file.strings
@@ -160,5 +178,49 @@ struct XCStringsReader {
             missingLanguages: missingLanguages,
             coveragePercent: coveragePercent
         )
+    }
+
+    private func untranslatedIssue(file: String, language: String, key: String, localization: Localization?) -> UntranslatedIssue? {
+        guard let localization else {
+            return UntranslatedIssue(file: file, language: language, key: key, reason: .missingLocalization)
+        }
+
+        if let stringUnit = localization.stringUnit {
+            if stringUnit.value.isEmpty {
+                return UntranslatedIssue(file: file, language: language, key: key, reason: .emptyValue)
+            }
+            if stringUnit.state != "translated" {
+                return UntranslatedIssue(file: file, language: language, key: key, reason: .stateNotTranslated, state: stringUnit.state)
+            }
+            return nil
+        }
+
+        if let variations = localization.variations {
+            return untranslatedVariationIssue(file: file, language: language, key: key, variations: variations)
+        }
+
+        return UntranslatedIssue(file: file, language: language, key: key, reason: .missingStringUnit)
+    }
+
+    private func untranslatedVariationIssue(file: String, language: String, key: String, variations: Variations) -> UntranslatedIssue? {
+        let values = variations.allValues
+
+        guard !values.isEmpty else {
+            return UntranslatedIssue(file: file, language: language, key: key, reason: .missingVariationValues)
+        }
+
+        for value in values {
+            guard let stringUnit = value.stringUnit else {
+                return UntranslatedIssue(file: file, language: language, key: key, reason: .missingVariationStringUnit)
+            }
+            if stringUnit.value.isEmpty {
+                return UntranslatedIssue(file: file, language: language, key: key, reason: .emptyVariationValue)
+            }
+            if stringUnit.state != "translated" {
+                return UntranslatedIssue(file: file, language: language, key: key, reason: .variationStateNotTranslated, state: stringUnit.state)
+            }
+        }
+
+        return nil
     }
 }

--- a/Tests/XCStringsCLITests/CheckUntranslatedCommandTests.swift
+++ b/Tests/XCStringsCLITests/CheckUntranslatedCommandTests.swift
@@ -1,0 +1,151 @@
+import ArgumentParser
+import Foundation
+import Testing
+@testable import XCStringsCLI
+@testable import XCStringsKit
+
+@Suite("check untranslated CLI command")
+struct CheckUntranslatedCommandTests {
+    @Test("rejects invalid argument combinations", arguments: ValidationCase.invalidCases)
+    func rejectsInvalidArgumentCombinations(testCase: ValidationCase) throws {
+        #expect(throws: Error.self) {
+            _ = try CheckCommand.Untranslated.parse(testCase.arguments)
+        }
+    }
+
+    @Test("throws exit code one for untranslated entries in normal CLI mode")
+    func throwsExitCodeForUntranslatedEntries() async throws {
+        let path = try createTempFile(content: Self.untranslatedFixture)
+        defer { removeTempFile(at: path) }
+
+        let command = try CheckCommand.Untranslated.parse(["--files", path, "--languages", "ja"])
+
+        await #expect(throws: ExitCode.self) {
+            try await command.run()
+        }
+    }
+
+    @Test("does not throw for complete translations")
+    func doesNotThrowForCompleteTranslations() async throws {
+        let path = try createTempFile(content: Self.completeFixture)
+        defer { removeTempFile(at: path) }
+
+        let command = try CheckCommand.Untranslated.parse(["--files", path, "--languages", "ja"])
+
+        try await command.run()
+    }
+
+    @Test("builds Codex hook JSON payload")
+    func buildsCodexHookPayload() throws {
+        let command = try CheckCommand.Untranslated.parse(["--files", "/tmp/Localizable.xcstrings", "--languages", "ja"])
+        let result = UntranslatedCheckResult(issues: [
+            UntranslatedIssue(file: "/tmp/Localizable.xcstrings", language: "ja", key: "Hello", reason: .missingLocalization),
+        ])
+
+        let output = try #require(command.codexHookOutput(for: result))
+        let json = try encode(output)
+
+        #expect(json.contains("\"decision\":\"block\""))
+        #expect(json.contains("\"hookEventName\":\"PostToolUse\""))
+        #expect(json.contains("Hello"))
+        #expect(json.contains("missing localization"))
+    }
+
+    @Test("builds Claude hook JSON payload")
+    func buildsClaudeHookPayload() throws {
+        let command = try CheckCommand.Untranslated.parse(["--files", "/tmp/Localizable.xcstrings", "--languages", "ja"])
+        let result = UntranslatedCheckResult(issues: [
+            UntranslatedIssue(file: "/tmp/Localizable.xcstrings", language: "ja", key: "Hello", reason: .missingLocalization),
+        ])
+
+        let output = try #require(command.claudeHookOutput(for: result))
+        let json = try encode(output)
+
+        #expect(json.contains("\"decision\":\"block\""))
+        #expect(!json.contains("hookSpecificOutput"))
+        #expect(json.contains("Hello"))
+        #expect(json.contains("missing localization"))
+    }
+
+    @Test("returns no hook payload when complete")
+    func returnsNoHookPayloadWhenComplete() throws {
+        let command = try CheckCommand.Untranslated.parse(["--files", "/tmp/Localizable.xcstrings", "--languages", "ja"])
+        let result = UntranslatedCheckResult(issues: [])
+
+        #expect(command.codexHookOutput(for: result) == nil)
+        #expect(command.claudeHookOutput(for: result) == nil)
+    }
+
+    private func createTempFile(content: String) throws -> String {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cli_test_\(UUID().uuidString).xcstrings")
+            .path
+        try content.write(toFile: path, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    private func removeTempFile(at path: String) {
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    private func encode(_ value: some Encodable) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(value)
+        return try #require(String(data: data, encoding: .utf8))
+    }
+
+    private static let completeFixture = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "Hello": {
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Hello" } },
+            "ja": { "stringUnit": { "state": "translated", "value": "こんにちは" } }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+
+    private static let untranslatedFixture = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "Hello": {
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Hello" } }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
+}
+
+struct ValidationCase: CustomTestStringConvertible {
+    let testDescription: String
+    let arguments: [String]
+
+    static let invalidCases = [
+        ValidationCase(
+            testDescription: "missing files",
+            arguments: ["--languages", "ja"]
+        ),
+        ValidationCase(
+            testDescription: "missing languages",
+            arguments: ["--files", "/tmp/Localizable.xcstrings"]
+        ),
+        ValidationCase(
+            testDescription: "mutually exclusive hook flags",
+            arguments: [
+                "--files", "/tmp/Localizable.xcstrings",
+                "--languages", "ja",
+                "--codex-hook",
+                "--claude-hook",
+            ]
+        ),
+    ]
+}

--- a/Tests/XCStringsKitTests/ListOperationsTests.swift
+++ b/Tests/XCStringsKitTests/ListOperationsTests.swift
@@ -164,4 +164,61 @@ struct ListOperationsTests {
         #expect(result.files.isEmpty)
         #expect(result.totalStaleKeys == 0)
     }
+
+    // MARK: - Untranslated Check Tests
+
+    @Test("checkUntranslated reports missing, empty, stale state, and variation issues")
+    func checkUntranslatedReportsIssues() throws {
+        let path = try TestHelper.createTempFile(content: TestFixtures.untranslatedCheckCases)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let result = try XCStringsParser.checkUntranslated(paths: [path], languages: ["ja"])
+
+        #expect(result.isComplete == false)
+        #expect(result.issues == [
+            UntranslatedIssue(file: path, language: "ja", key: "EmptyValue", reason: .emptyValue),
+            UntranslatedIssue(file: path, language: "ja", key: "MissingLocalization", reason: .missingLocalization),
+            UntranslatedIssue(file: path, language: "ja", key: "NeedsReview", reason: .stateNotTranslated, state: "needs_review"),
+            UntranslatedIssue(file: path, language: "ja", key: "VariationNeedsReview", reason: .variationStateNotTranslated, state: "new"),
+        ])
+    }
+
+    @Test("checkUntranslated excludes non-translatable keys")
+    func checkUntranslatedExcludesNonTranslatableKeys() throws {
+        let path = try TestHelper.createTempFile(content: TestFixtures.untranslatedCheckCases)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let result = try XCStringsParser.checkUntranslated(paths: [path], languages: ["ja"])
+
+        #expect(!result.issues.contains { $0.key == "BrandName" })
+    }
+
+    @Test("checkUntranslated handles multiple files and languages")
+    func checkUntranslatedHandlesMultipleFilesAndLanguages() throws {
+        let path1 = try TestHelper.createTempFile(content: TestFixtures.singleKeyMultipleLangs)
+        let path2 = try TestHelper.createTempFile(content: TestFixtures.multipleKeysPartialTranslations)
+        defer {
+            TestHelper.removeTempFile(at: path1)
+            TestHelper.removeTempFile(at: path2)
+        }
+
+        let result = try XCStringsParser.checkUntranslated(paths: [path1, path2], languages: ["de", "ja"])
+
+        #expect(result.issues == [
+            UntranslatedIssue(file: path2, language: "de", key: "Goodbye", reason: .missingLocalization),
+            UntranslatedIssue(file: path2, language: "de", key: "Hello", reason: .missingLocalization),
+            UntranslatedIssue(file: path2, language: "ja", key: "Goodbye", reason: .missingLocalization),
+        ])
+    }
+
+    @Test("checkUntranslated is complete when all requested languages are translated")
+    func checkUntranslatedComplete() throws {
+        let path = try TestHelper.createTempFile(content: TestFixtures.singleKeyMultipleLangs)
+        defer { TestHelper.removeTempFile(at: path) }
+
+        let result = try XCStringsParser.checkUntranslated(paths: [path], languages: ["de", "ja"])
+
+        #expect(result.isComplete)
+        #expect(result.issues.isEmpty)
+    }
 }

--- a/Tests/XCStringsKitTests/TestFixtures.swift
+++ b/Tests/XCStringsKitTests/TestFixtures.swift
@@ -534,6 +534,58 @@ enum TestFixtures {
       "version": "1.0"
     }
     """
+
+    /// Keys covering untranslated check edge cases
+    static let untranslatedCheckCases = """
+    {
+      "sourceLanguage": "en",
+      "strings": {
+        "Complete": {
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Complete" } },
+            "ja": { "stringUnit": { "state": "translated", "value": "完了" } }
+          }
+        },
+        "MissingLocalization": {
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Missing" } }
+          }
+        },
+        "EmptyValue": {
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Empty" } },
+            "ja": { "stringUnit": { "state": "translated", "value": "" } }
+          }
+        },
+        "NeedsReview": {
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Review" } },
+            "ja": { "stringUnit": { "state": "needs_review", "value": "レビュー" } }
+          }
+        },
+        "VariationNeedsReview": {
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Count" } },
+            "ja": {
+              "variations": {
+                "plural": {
+                  "one": { "stringUnit": { "state": "translated", "value": "%lld 件" } },
+                  "other": { "stringUnit": { "state": "new", "value": "%lld 件" } }
+                }
+              }
+            }
+          }
+        },
+        "BrandName": {
+          "shouldTranslate": false,
+          "localizations": {
+            "en": { "stringUnit": { "state": "translated", "value": "Brand" } }
+          }
+        }
+      },
+      "version": "1.0"
+    }
+    """
 }
 
 /// Test helper utilities

--- a/docsync.yml
+++ b/docsync.yml
@@ -31,7 +31,7 @@ rules:
   doc: README.md
   message: "CLI command surface changed \u2014 update README (CLI usage section) if
     commands or options changed."
-  checksum: de43e9f0454e2f61e898e508fd0a8e229cb946146fc001ce72ac61bb35bc6da7
+  checksum: d6f52bbd76c1b5591f702feab89b0f7422c78196179ddbd20cd7213d14705940
 - name: readme-core
   sources:
   - Sources/XCStringsKit/Models/XCStrings.swift
@@ -40,7 +40,7 @@ rules:
   doc: README.md
   message: "Core data model or error types changed \u2014 update README if the behavior
     or output format changed."
-  checksum: f00f5be2a766ab85fc0d4f3a092b9edd6fab788d20329893b468823e8f1c7bba
+  checksum: e80adb8af9aeb3df931cd26a36767d7df4dcd9422e134883bcf7bbb51a1df125
 - name: agents-claude
   sources:
   - Package.swift
@@ -50,4 +50,4 @@ rules:
   doc: CLAUDE.md
   message: "Core architecture changed \u2014 update CLAUDE.md if the architecture
     description is affected."
-  checksum: df0ec9a4b41b1a39a8a8bef6173e519a574ded0532acd3ced8098178b7e9f1bd
+  checksum: 0b381044188af699483c1bf1c63b3c3e58e21f47e86b34088dda700be193c3d9


### PR DESCRIPTION
## Summary
- Add a CLI-only check untranslated command that requires explicit files and languages
- Add normal JSON output plus Codex and Claude hook-compatible blocking payloads
- Add core detection for missing, empty, stale, and variation untranslated issues with tests and docs