### PR TITLE
Cache decoded catalog and coalesce MCP writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ swift build -c release # Release build
 - `XCStringsParser.swift` - Facade for file operations, including multi-file untranslated checks
 - `XCStringsReader.swift` - Read operations (list, get, check), including key metadata, `shouldTranslate == false` handling, and untranslated issue detection for specific files and languages
 - `XCStringsWriter.swift` - Write operations (add, update, delete, rename)
+- `XCStringsFileHandler.swift` - Disk I/O facade; `load`/`save` route through `XCStringsStore`, raw disk access lives in its static helpers
+- `XCStringsStore.swift` - Process-wide cache with optional coalesced (debounced) writes. The MCP server enables coalescing and flushes on shutdown (EOF/SIGINT/SIGTERM); the CLI stays write-through. Tunable via `XCSTRINGS_FLUSH_MS` (default 250ms; 0 = write-through)
 - `XCStringsFileEncoder.swift` - Deterministic xcstrings JSON encoding with Xcode-like key order
 - `XCStringsKeySorter.swift` - Xcode-like natural sorting for string catalog keys
 - `XCStringsStatsCalculator.swift` - Coverage and progress stats; non-translatable keys are excluded from language totals

--- a/Sources/XCStringsKit/XCStringsFileHandler.swift
+++ b/Sources/XCStringsKit/XCStringsFileHandler.swift
@@ -1,6 +1,11 @@
 import Foundation
 
-/// Handles file I/O operations for xcstrings files
+/// Handles file I/O operations for xcstrings files.
+///
+/// Reads and writes are routed through ``XCStringsStore`` so a long-lived
+/// process (the MCP server) can cache the decoded catalog and coalesce writes.
+/// The raw, cache-bypassing disk access lives in the static helpers below, which
+/// the store uses to perform the actual reads and writes.
 struct XCStringsFileHandler {
     private let path: String
 
@@ -8,8 +13,31 @@ struct XCStringsFileHandler {
         self.path = path
     }
 
-    /// Load xcstrings file from disk
+    /// Load xcstrings file (served from the cache when valid)
     func load() throws -> XCStringsFile {
+        try XCStringsStore.shared.load(path: path)
+    }
+
+    /// Save xcstrings file (may be coalesced when running under the MCP server)
+    func save(_ file: XCStringsFile) throws {
+        try XCStringsStore.shared.save(path: path, file: file)
+    }
+
+    /// Create a new xcstrings file
+    func create(sourceLanguage: String, overwrite: Bool = false) throws {
+        if !overwrite, FileManager.default.fileExists(atPath: path) {
+            throw XCStringsError.fileAlreadyExists(path: path)
+        }
+
+        let file = XCStringsFile(sourceLanguage: sourceLanguage)
+        try Self.writeToDisk(path: path, file: file)
+        XCStringsStore.shared.invalidate(path: path)
+    }
+
+    // MARK: - Raw Disk I/O
+
+    /// Read and decode an xcstrings file directly from disk, bypassing the cache.
+    static func readFromDisk(path: String) throws -> XCStringsFile {
         let url = URL(fileURLWithPath: path)
         guard FileManager.default.fileExists(atPath: path) else {
             throw XCStringsError.fileNotFound(path: path)
@@ -30,33 +58,10 @@ struct XCStringsFileHandler {
         }
     }
 
-    /// Save xcstrings file to disk
-    func save(_ file: XCStringsFile) throws {
+    /// Encode and atomically write an xcstrings file directly to disk, bypassing the cache.
+    static func writeToDisk(path: String, file: XCStringsFile) throws {
         let url = URL(fileURLWithPath: path)
 
-        let data: Data
-        do {
-            data = try XCStringsFileEncoder.encode(file)
-        } catch {
-            throw XCStringsError.writeError(path: path, reason: error.localizedDescription)
-        }
-
-        do {
-            try data.write(to: url, options: .atomic)
-        } catch {
-            throw XCStringsError.writeError(path: path, reason: error.localizedDescription)
-        }
-    }
-
-    /// Create a new xcstrings file
-    func create(sourceLanguage: String, overwrite: Bool = false) throws {
-        let url = URL(fileURLWithPath: path)
-
-        if !overwrite, FileManager.default.fileExists(atPath: path) {
-            throw XCStringsError.fileAlreadyExists(path: path)
-        }
-
-        let file = XCStringsFile(sourceLanguage: sourceLanguage)
         let data: Data
         do {
             data = try XCStringsFileEncoder.encode(file)

--- a/Sources/XCStringsKit/XCStringsStore.swift
+++ b/Sources/XCStringsKit/XCStringsStore.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Process-wide cache for xcstrings files with optional coalesced writes.
+///
+/// The MCP server is a long-lived process, so re-reading and re-encoding a
+/// multi-megabyte catalog on every single call dominates latency. This store
+/// keeps the decoded `XCStringsFile` in memory — validated against the file's
+/// on-disk signature so external edits (e.g. Xcode re-extracting keys) are
+/// detected — and, when coalescing is enabled, defers disk writes. A burst of
+/// mutations then collapses into a single encode + atomic write.
+///
+/// Coalescing is opt-in via ``enableCoalescing(delayMilliseconds:)`` and is only
+/// turned on by the MCP server, which guarantees a final ``flushAll()`` on
+/// shutdown. The CLI keeps the default write-through behaviour so one-shot
+/// commands stay durable.
+///
+/// Set `XCSTRINGS_FLUSH_MS=0` to force write-through even under the MCP server.
+package final class XCStringsStore: @unchecked Sendable {
+    package static let shared = XCStringsStore()
+
+    private struct Signature: Equatable {
+        let modificationDate: Date?
+        let size: Int?
+    }
+
+    private struct Entry {
+        var file: XCStringsFile
+        var diskSignature: Signature
+        var dirty: Bool
+    }
+
+    private let lock = NSLock()
+    private var entries: [String: Entry] = [:]
+    private var pendingFlushes: [String: DispatchWorkItem] = [:]
+
+    private var coalescingEnabled = false
+    private var flushDelay: DispatchTimeInterval = .milliseconds(250)
+    private let flushQueue = DispatchQueue(label: "com.xcstrings-crud.store.flush", qos: .utility)
+
+    private init() {}
+
+    // MARK: - Configuration
+
+    /// Enable coalesced (debounced) writes. Intended to be called once at MCP server startup.
+    package func enableCoalescing(delayMilliseconds: Int) {
+        lock.lock()
+        coalescingEnabled = true
+        flushDelay = .milliseconds(max(0, delayMilliseconds))
+        lock.unlock()
+    }
+
+    // MARK: - Read
+
+    /// Return the cached file when it is still valid, otherwise read it from disk.
+    package func load(path: String) throws -> XCStringsFile {
+        lock.lock()
+        if let entry = entries[path], entry.dirty || entry.diskSignature == signature(of: path) {
+            let file = entry.file
+            lock.unlock()
+            return file
+        }
+        lock.unlock()
+        return try readThrough(path: path)
+    }
+
+    // MARK: - Write
+
+    /// Store the updated file. Flushes immediately unless coalescing is enabled.
+    package func save(path: String, file: XCStringsFile) throws {
+        lock.lock()
+        let signature = entries[path]?.diskSignature ?? Signature(modificationDate: nil, size: nil)
+        entries[path] = Entry(file: file, diskSignature: signature, dirty: true)
+        let coalesce = coalescingEnabled && flushDelay != .milliseconds(0)
+        lock.unlock()
+
+        if coalesce {
+            scheduleFlush(path: path)
+        } else {
+            try flush(path: path)
+        }
+    }
+
+    /// Drop any cached state for a path (e.g. after the file is recreated on disk).
+    package func invalidate(path: String) {
+        lock.lock()
+        pendingFlushes[path]?.cancel()
+        pendingFlushes[path] = nil
+        entries[path] = nil
+        lock.unlock()
+    }
+
+    /// Write pending changes for a single path to disk.
+    package func flush(path: String) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        pendingFlushes[path]?.cancel()
+        pendingFlushes[path] = nil
+        guard var entry = entries[path], entry.dirty else { return }
+        try XCStringsFileHandler.writeToDisk(path: path, file: entry.file)
+        entry.diskSignature = signature(of: path)
+        entry.dirty = false
+        entries[path] = entry
+    }
+
+    /// Flush every path with pending changes. Used on server shutdown.
+    package func flushAll() {
+        lock.lock()
+        let paths = entries.compactMap { $0.value.dirty ? $0.key : nil }
+        lock.unlock()
+        for path in paths {
+            try? flush(path: path)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func readThrough(path: String) throws -> XCStringsFile {
+        let file = try XCStringsFileHandler.readFromDisk(path: path)
+        lock.lock()
+        entries[path] = Entry(file: file, diskSignature: signature(of: path), dirty: false)
+        lock.unlock()
+        return file
+    }
+
+    private func scheduleFlush(path: String) {
+        let work = DispatchWorkItem { [weak self] in
+            try? self?.flush(path: path)
+        }
+        lock.lock()
+        pendingFlushes[path]?.cancel()
+        pendingFlushes[path] = work
+        let delay = flushDelay
+        lock.unlock()
+        flushQueue.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    private func signature(of path: String) -> Signature {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: path)
+        return Signature(
+            modificationDate: attributes?[.modificationDate] as? Date,
+            size: attributes?[.size] as? Int
+        )
+    }
+}

--- a/Sources/XCStringsMCP/MCPServer.swift
+++ b/Sources/XCStringsMCP/MCPServer.swift
@@ -6,6 +6,10 @@ public struct XCStringsMCPServer {
     public init() {}
 
     public func run() async throws {
+        let flushMilliseconds = ProcessInfo.processInfo.environment["XCSTRINGS_FLUSH_MS"].flatMap(Int.init) ?? 250
+        XCStringsStore.shared.enableCoalescing(delayMilliseconds: flushMilliseconds)
+        Self.installShutdownHandlers()
+
         let server = Server(
             name: "xcstrings-mcp",
             version: "0.2.0",
@@ -27,6 +31,29 @@ public struct XCStringsMCPServer {
         let transport = StdioTransport()
         try await server.start(transport: transport)
         await server.waitUntilCompleted()
+
+        // Persist any coalesced writes before exiting on graceful (EOF) shutdown.
+        XCStringsStore.shared.flushAll()
+    }
+
+    // MARK: - Shutdown Handling
+
+    /// Signal sources kept alive for the process lifetime. Created once via the
+    /// thread-safe lazy initialization of a `static let`, so no mutable global is needed.
+    private static let shutdownSignalSources: [DispatchSourceSignal] = [SIGINT, SIGTERM].map { signalNumber in
+        signal(signalNumber, SIG_IGN)
+        let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global())
+        source.setEventHandler {
+            XCStringsStore.shared.flushAll()
+            exit(0)
+        }
+        source.resume()
+        return source
+    }
+
+    /// Flush pending coalesced writes on SIGINT/SIGTERM so deferred edits are not lost.
+    private static func installShutdownHandlers() {
+        _ = shutdownSignalSources
     }
 
     // MARK: - Tool Definitions

--- a/docsync.yml
+++ b/docsync.yml
@@ -13,7 +13,7 @@ rules:
   doc: README.md
   message: "MCP tool handlers changed \u2014 update README (MCP tools table) if tools
     were added, removed, or renamed."
-  checksum: 4d8c87b4d1e43f1d21a9ae57d16d88186c86ca5629e1cc9f2640a158b41bf489
+  checksum: 5a22a07cbf028b8682f7ab5ebac8b81f168e8d84224046aaca7bbce50fa66da0
 - name: readme-cli
   sources:
   - Sources/XCStringsCLI/XCStringsCLI.swift
@@ -50,4 +50,4 @@ rules:
   doc: CLAUDE.md
   message: "Core architecture changed \u2014 update CLAUDE.md if the architecture
     description is affected."
-  checksum: 0b381044188af699483c1bf1c63b3c3e58e21f47e86b34088dda700be193c3d9
+  checksum: 9effdb51618528a9dbf93438a8dfa0094f3d9c0091f3a2c137901f36ad7657bc


### PR DESCRIPTION
## Summary

Speeds up MCP write operations (add / update / delete / rename), which were slow on large `.xcstrings` catalogs.

Previously every write read, decoded, re-encoded, and rewrote the **entire** file. For multi-megabyte catalogs this dominated latency — especially when an assistant issues many single-key writes in a row, each paying the full decode + encode + write cost.

This PR introduces **`XCStringsStore`**, a process-wide cache:

- Keeps the decoded `XCStringsFile` in memory, validated against the file's on-disk signature (modification date + size) so **external edits (e.g. Xcode re-extracting keys) are detected** and trigger a reload.
- When coalescing is enabled, **defers disk writes** and collapses a burst of mutations into a single encode + atomic write.
- `XCStringsFileHandler.load`/`save` now route through the store; the raw, cache-bypassing disk I/O moved to its static helpers (`readFromDisk` / `writeToDisk`).

### Safety / behaviour

- **Coalescing is opt-in** and only enabled by the MCP server, which flushes pending writes on shutdown — both graceful EOF and `SIGINT`/`SIGTERM`.
- The **CLI keeps the default write-through behaviour**, so one-shot commands remain durable (no risk of losing a write when the process exits immediately).
- Tunable via `XCSTRINGS_FLUSH_MS` (default `250`; set `0` to force write-through).
- Reads are served from the cache and reflect pending in-memory edits, so stats/get/list calls stay consistent within the process.

## Benchmark

40 sequential single-key `xcstrings_add_translation` calls over the MCP server on a 4.4 MB catalog:

| Mode | Time | Persisted |
|---|---|---|
| Coalesced (default) | **0.70s** | 40/40 |
| Write-through (`XCSTRINGS_FLUSH_MS=0`, prior behaviour) | 10.80s | 40/40 |

~15× faster, with all writes correctly persisted after shutdown.

> Tip for clients: `xcstrings_batch_add_translations` remains the best choice for many keys at once (one decode/encode); this change additionally helps the common single-write-at-a-time pattern.

## Testing

- `make check` passes (swiftformat lint, swiftlint, 155 tests, docsync).
- End-to-end MCP run verified: all deferred writes persist on EOF and on `SIGINT`/`SIGTERM`.
- `CLAUDE.md` updated and `docsync` checksums resynced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)